### PR TITLE
feat: Tailwind CSS v4 Design System Setup (Zudo)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,525 @@
+@import 'tailwindcss';
+
+@layer base {
+  :root {
+    /* colors */
+    --zd-color-black: rgb(28, 25, 23);
+    --zd-color-white: rgb(214, 211, 209);
+    --zd-color-link: #fff; /* Link color is now white, with text-shadow for visibility */
+    --zd-color-active: #713f12;
+    --zd-color-gray: rgb(120, 113, 108);
+    --zd-color-gray2: #201f1f;
+    --zd-color-strong: #d97706; /* Orange/amber for strong text emphasis (was previously link color) */
+    --zd-color-sold: oklch(
+      50.5% 0.213 27.518
+    ); /* Orange/amber for strong text emphasis (was previously link color) */
+    --zd-color-notify: #22c55e;
+    --zd-color-error: #f43f5e;
+    --zd-color-debug: #ff0000;
+    --zd-color-price: #fbbf24; /* yellow-400 */
+    --zd-color-outline: #ea580c; /* orange-600 for focus/active outlines */
+    --zd-color-mercari-corporate: #b91c1c; /* red-700 for Mercari brand */
+
+    /* shadows */
+    --zd-text-shadow-md: 0.05em 0.05em 0 #000;
+
+    /* line-height */
+    --zd-lineHeight-none: 1;
+    --zd-lineHeight-tight: 1.4;
+    --zd-lineHeight-snug: 1.6;
+    --zd-lineHeight-normal: 1.8;
+    --zd-lineHeight-relaxed: 1;
+    --zd-lineHeight-loose: 2.3;
+
+    /* font-size / line-height combinations */
+    --zd-font-xs-size: 1rem;
+    --zd-font-xs-lineHeight: 1.4;
+    --zd-font-sm-size: 1.1rem;
+    --zd-font-sm-lineHeight: 1.5;
+    --zd-font-base-size: 1.4rem;
+    --zd-font-base-lineHeight: 1.7;
+    --zd-font-lg-size: 1.6rem;
+    --zd-font-lg-lineHeight: 1.5;
+    --zd-font-xl-size: 1.9rem;
+    --zd-font-xl-lineHeight: 1.4;
+    --zd-font-2xl-size: 2.8rem;
+    --zd-font-2xl-lineHeight: 1.35;
+    --zd-font-3xl-size: 3.2rem;
+    --zd-font-3xl-lineHeight: 1.3;
+    --zd-font-4xl-size: 4rem;
+    --zd-font-4xl-lineHeight: 1.3;
+    --zd-font-5xl-size: 4.8rem;
+    --zd-font-5xl-lineHeight: 1.3;
+
+    /* spacing */
+    --zd-spacing-1px: 1px;
+
+    --zd-spacing-hgap-2xs: 5px;
+    --zd-spacing-hgap-xs: 12px;
+    --zd-spacing-hgap-sm: 20px;
+    --zd-spacing-hgap-md: 40px;
+    --zd-spacing-hgap-md-x2: 80px;
+    --zd-spacing-hgap-lg: 60px;
+    --zd-spacing-hgap-lg-x2: 120px;
+    --zd-spacing-hgap-xl: 100px;
+    --zd-spacing-hgap-2xl: 250px;
+
+    --zd-spacing-vgap-2xs: 4px;
+    --zd-spacing-vgap-xs: 8px;
+    --zd-spacing-vgap-sm: 20px;
+    --zd-spacing-vgap-md: 35px;
+    --zd-spacing-vgap-lg: 50px;
+    --zd-spacing-vgap-xl: 65px;
+    --zd-spacing-vgap-2xl: 80px;
+  }
+}
+
+/* Zudo Design System - Theme Configuration */
+@theme {
+  /* STEP 1: Reset all Tailwind defaults using wildcard patterns
+     This removes ALL default Tailwind utilities (p-4, bg-blue-500, etc.) */
+  --spacing-*: initial;
+  --color-*: initial;
+  --font-size-*: initial;
+  --font-family-*: initial;
+  --font-weight-*: initial;
+  --line-height-*: initial;
+  --letter-spacing-*: initial;
+  --text-*: initial;
+  --border-radius-*: initial;
+  --border-width-*: initial;
+  --border-color-*: initial;
+  --shadow-*: initial;
+  --width-*: initial;
+  --height-*: initial;
+  --max-width-*: initial;
+  --max-height-*: initial;
+  --min-width-*: initial;
+  --min-height-*: initial;
+
+  /* STEP 2: Define ONLY Zudo Design System tokens
+     Only these custom tokens will be available as Tailwind utilities */
+
+  /* Spacing - replaces all Tailwind default spacing */
+  --spacing-0: 0;
+  --spacing-1px: var(--zd-spacing-1px);
+  --spacing-hgap-2xs: var(--zd-spacing-hgap-2xs);
+  --spacing-hgap-xs: var(--zd-spacing-hgap-xs);
+  --spacing-hgap-sm: var(--zd-spacing-hgap-sm);
+  --spacing-hgap-md: var(--zd-spacing-hgap-md);
+  --spacing-hgap-md-x2: var(--zd-spacing-hgap-md-x2);
+  --spacing-hgap-lg: var(--zd-spacing-hgap-lg);
+  --spacing-hgap-lg-x2: var(--zd-spacing-hgap-lg-x2);
+  --spacing-hgap-xl: var(--zd-spacing-hgap-xl);
+  --spacing-hgap-2xl: var(--zd-spacing-hgap-2xl);
+  --spacing-vgap-2xs: var(--zd-spacing-vgap-2xs);
+  --spacing-vgap-xs: var(--zd-spacing-vgap-xs);
+  --spacing-vgap-sm: var(--zd-spacing-vgap-sm);
+  --spacing-vgap-md: var(--zd-spacing-vgap-md);
+  --spacing-vgap-lg: var(--zd-spacing-vgap-lg);
+  --spacing-vgap-xl: var(--zd-spacing-vgap-xl);
+  --spacing-vgap-2xl: var(--zd-spacing-vgap-2xl);
+
+  /* Colors - replaces all Tailwind default colors */
+  --color-debug: var(--zd-color-debug);
+  --color-zd-black: var(--zd-color-black);
+  --color-zd-white: var(--zd-color-white);
+  --color-zd-link: var(--zd-color-link);
+  --color-zd-active: var(--zd-color-active);
+  --color-zd-gray: var(--zd-color-gray);
+  --color-zd-gray2: var(--zd-color-gray2);
+  --color-zd-notify: var(--zd-color-notify);
+  --color-zd-error: var(--zd-color-error);
+  --color-zd-price: var(--zd-color-price);
+  --color-zd-outline: var(--zd-color-outline);
+  --color-zd-mercari-corporate: var(--zd-color-mercari-corporate);
+  --color-zd-strong: var(--zd-color-strong);
+  --color-zd-sold: var(--zd-color-sold);
+  --color-black: #000; /* Pure black for utilities */
+  --color-white: #fff; /* Pure white for utilities */
+  --color-transparent: transparent; /* Transparent for utilities */
+
+  /* Typography - Font sizes with line heights (Tailwind v4 format) */
+  --text-xs: var(--zd-font-xs-size);
+  --text-xs--line-height: var(--zd-font-xs-lineHeight);
+  --text-sm: var(--zd-font-sm-size);
+  --text-sm--line-height: var(--zd-font-sm-lineHeight);
+  --text-base: var(--zd-font-base-size);
+  --text-base--line-height: var(--zd-font-base-lineHeight);
+  --text-lg: var(--zd-font-lg-size);
+  --text-lg--line-height: var(--zd-font-lg-lineHeight);
+  --text-xl: var(--zd-font-xl-size);
+  --text-xl--line-height: var(--zd-font-xl-lineHeight);
+  --text-2xl: var(--zd-font-2xl-size);
+  --text-2xl--line-height: var(--zd-font-2xl-lineHeight);
+  --text-3xl: var(--zd-font-3xl-size);
+  --text-3xl--line-height: var(--zd-font-3xl-lineHeight);
+  --text-4xl: var(--zd-font-4xl-size);
+  --text-4xl--line-height: var(--zd-font-4xl-lineHeight);
+  --text-5xl: var(--zd-font-5xl-size);
+  --text-5xl--line-height: var(--zd-font-5xl-lineHeight);
+
+  /* Line heights - standalone */
+  --line-height-none: var(--zd-lineHeight-none);
+  --line-height-tight: var(--zd-lineHeight-tight);
+  --line-height-snug: var(--zd-lineHeight-snug);
+  --line-height-normal: var(--zd-lineHeight-normal);
+  --line-height-relaxed: var(--zd-lineHeight-relaxed);
+  --line-height-loose: var(--zd-lineHeight-loose);
+
+  /* Font families with Japanese fallbacks */
+  --font-noto:
+    'Noto Sans', 'Noto Sans JP', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    'Hiragino Sans', 'Hiragino Kaku Gothic Pro', 'Yu Gothic', Meiryo, sans-serif;
+  --font-futura:
+    Futura, Jost, 'Century Gothic', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Noto Sans', 'Noto Sans JP', 'Hiragino Sans', sans-serif;
+  --font-sans:
+    Helvetica, Arial, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans JP',
+    'Hiragino Sans', 'Hiragino Kaku Gothic Pro', 'Yu Gothic', Meiryo, sans-serif;
+  --font-mono: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+
+  /* Font weights (Tailwind defaults) */
+  --font-weight-thin: 100;
+  --font-weight-extralight: 200;
+  --font-weight-light: 300;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-weight-extrabold: 800;
+  --font-weight-black: 900;
+
+  /* Breakpoints */
+  --breakpoint-sm: 580px;
+  --breakpoint-md: 740px;
+  --breakpoint-lg: 980px;
+  --breakpoint-xl: 1280px;
+  --breakpoint-2xl: 1630px;
+  --breakpoint-3xl: 1800px;
+
+  /* Border widths */
+  --border-width-default: 1px;
+  --border-width-0: 0px;
+  --border-width-1: 1px;
+  --border-width-2: 2px;
+  --border-width-3: 3px;
+  --border-width-4: 4px;
+  --border-width-5: 5px;
+  --border-width-10: 10px;
+
+  /* Border radius */
+  --radius-xs: 0.125rem; /* 2px */
+  --radius-sm: 0.25rem; /* 4px */
+  --radius-md: 0.375rem; /* 6px */
+  --radius-lg: 0.5rem; /* 8px */
+
+  /* Box shadows (Tailwind defaults) */
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+  --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
+  --shadow-none: 0 0 #0000;
+
+  /* Common width/height utilities */
+  --width-full: 100%;
+  --height-full: 100%;
+  --min-width-0: 0;
+  --min-height-0: 0;
+  --min-height-screen: 100vh;
+  --max-width-full: 100%;
+  --max-height-full: 100%;
+
+  /* Max-width size scale (xl through 7xl) */
+  --max-width-xs: 20rem; /* 320px */
+  --max-width-sm: 24rem; /* 384px */
+  --max-width-md: 28rem; /* 448px */
+  --max-width-lg: 32rem; /* 512px */
+  --max-width-xl: 36rem; /* 576px */
+  --max-width-2xl: 42rem; /* 672px */
+  --max-width-3xl: 48rem; /* 768px */
+  --max-width-4xl: 56rem; /* 896px */
+  --max-width-5xl: 64rem; /* 1024px */
+  --max-width-6xl: 72rem; /* 1152px */
+  --max-width-7xl: 80rem; /* 1280px */
+
+  /* Fractional max-widths */
+  --max-width-1\/2: 50%;
+  --max-width-1\/3: 33.333333%;
+  --max-width-2\/3: 66.666667%;
+  --max-width-1\/4: 25%;
+  --max-width-2\/4: 50%;
+  --max-width-3\/4: 75%;
+  --max-width-1\/5: 20%;
+  --max-width-2\/5: 40%;
+  --max-width-3\/5: 60%;
+  --max-width-4\/5: 80%;
+  --max-width-1\/6: 16.666667%;
+  --max-width-2\/6: 33.333333%;
+  --max-width-3\/6: 50%;
+  --max-width-4\/6: 66.666667%;
+  --max-width-5\/6: 83.333333%;
+
+  /* Fractional widths */
+  --width-1\/2: 50%;
+  --width-1\/3: 33.333333%;
+  --width-2\/3: 66.666667%;
+  --width-1\/4: 25%;
+  --width-2\/4: 50%;
+  --width-3\/4: 75%;
+  --width-1\/5: 20%;
+  --width-2\/5: 40%;
+  --width-3\/5: 60%;
+  --width-4\/5: 80%;
+  --width-1\/6: 16.666667%;
+  --width-2\/6: 33.333333%;
+  --width-3\/6: 50%;
+  --width-4\/6: 66.666667%;
+  --width-5\/6: 83.333333%;
+}
+
+@utility zd-gradient-black-to-transparent {
+  background: linear-gradient(to bottom, var(--zd-color-black) 30%, transparent);
+  background-repeat: repeat-x;
+}
+
+@utility zd-gradient-white-to-transparent {
+  background: linear-gradient(to bottom, var(--zd-color-white), transparent);
+  background-repeat: repeat-x;
+}
+
+@utility zd-hash {
+  letter-spacing: 0.15em;
+}
+
+@utility zd-invert-color-link {
+  @apply text-shadow-md outline-offset-4;
+  &:hover,
+  &:focus {
+    @apply text-zd-black bg-zd-white text-shadow-none no-underline;
+    @apply outline-2 rounded-xs outline-zd-outline;
+  }
+  &:active {
+    @apply text-zd-black;
+    @apply bg-zd-active;
+  }
+}
+
+@utility zd-invert-color-link--focus {
+  @apply text-zd-black bg-zd-white text-shadow-none no-underline;
+  @apply outline-2 rounded-xs outline-zd-outline outline-offset-4;
+}
+
+@utility zd-invert-color-link-inline {
+  @apply text-shadow-md;
+  &:hover,
+  &:active,
+  &:focus {
+    @apply text-black bg-zd-white text-shadow-none no-underline;
+  }
+}
+
+/* shadows */
+
+@utility text-shadow-md {
+  text-shadow: var(--zd-text-shadow-md);
+}
+@utility text-shadow-none {
+  text-shadow: none !important;
+}
+
+/* clearfix */
+@utility clearfix {
+  &::after {
+    content: '';
+    clear: both;
+    display: table;
+  }
+}
+
+/*
+  Base styles for HTML elements.
+  The default border color has changed to `currentcolor` in Tailwind CSS v4.
+*/
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: currentcolor;
+  }
+
+  html {
+    @apply underline-offset-4 bg-zd-black;
+    scroll-behavior: smooth;
+  }
+
+  /* Scroll offset for anchor navigation */
+  [id] {
+    scroll-margin-top: 100px;
+  }
+
+  body {
+    @apply text-base font-noto text-zd-white bg-zd-black font-light;
+    text-wrap: pretty;
+    /* Tribal pattern background from Gatsby html.js - properly URL-encoded */
+    background-image: url("data:image/svg+xml,%3Csvg id='patternId' width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3E%3Cdefs%3E%3Cpattern id='a' patternUnits='userSpaceOnUse' width='120' height='120.1' patternTransform='scale(2) rotate(45)'%3E%3Crect x='0' y='0' width='100%25' height='100%25' fill='hsla(0, 0%25, 4%25, 1)'/%3E%3Cpath d='M79.6-6.4v24.8H62.7V2.3h7.4v11h4.3V-1.9H58.5v24.6h25.4V-6.4H89v29.1h25.4V-1.9H98.5v16.1h4.2V2.3h7.4v16.1H93.2V-6.4zm-41.7 76v4.2H54V57.9H29.5v25.3h29.2v5.1H29.5v25.3H54V97.7H38.8v4.2h11v7.4H33.7V92.4h25v21.2h21v24.8l-17-15.9h11.6v-4.2H58.4v4.2l21.1 20.3h4.2v-29h5.1v29H93l21.1-20.3v-4.2H98.2v4.2h11.6l-16.9 16.1v-24.8h21.4V92.6h24.6l-16.1 16.9V97.9h-4.2v15.9h4.2l20.3-21.1v-4.2h-28.8v-5.1h28.8v-4.2l-20.3-21.1h-4.2V74h4.2V62.4l16.1 16.9h-24.6V58.1H92.9V33.3h16.9v16.1h-7.4V37.5h-4.2v16.1h15.9V29.1H88.8v29h-5.1v-29H58.5v24.5h15.9V38.4h-4.2v11h-7.4V33.3h16.9v24.8h-21v21.2h-25V62.4h16.1v7.4H37.9zm25-7.4h47.4v47.4H62.9zM0 52.5h52.5V0H0zM4 3.9h44.6v44.6H4zm-9.5 88.8h24.6v16.9H3v-7.4h11v-4.3H-1.2v15.9h24.5V88.4H-5.5v-5.1h28.8V57.9H-1.2v15.9h16.1v-4.2H3v-7.4h16.1v16.9H-5.5zm39.1-72h14.6L40.9 13zm-14.6 0h14.6L26.3 13zm-14.6 0H19L11.7 13zM4.1 8.6h44.7v3.3H4.1zm29.5 28.8h14.6l-7.3-7.6zm-14.6 0h14.6l-7.3-7.6zm-14.6 0H19l-7.3-7.6zm-.3 3.1h44.7v3.3H4.1zm0-15.1h44.7v3.3H4.1zm82.6 55.5a5.8 5.8 0 105.8 5.8c-.1-3.2-2.7-5.8-5.8-5.8zm0 15.9c-5.6 0-10.2-4.6-10.2-10.2s4.6-10.2 10.2-10.2S96.9 81 96.9 86.6c0 5.7-4.6 10.2-10.2 10.2zm-13.8 3.6h27.5V72.9H72.9zm31.9 4.4H68.5V68.5h36.3z' stroke-width='1' stroke='none' fill='hsla(259, 0%25, 8%25, 1)'/%3E%3C/pattern%3E%3C/defs%3E%3Crect width='800%25' height='800%25' transform='translate(0,0)' fill='url(%23a)'/%3E%3C/svg%3E");
+  }
+
+  input,
+  textarea {
+    @apply text-zd-black bg-zd-white;
+  }
+
+  input[type='search'] {
+    -webkit-appearance: none;
+  }
+
+  a {
+    @apply underline text-zd-white font-medium;
+  }
+
+  a:focus,
+  a:active {
+    @apply outline-2 outline-zd-outline rounded-xs;
+  }
+
+  a:active {
+    @apply text-zd-black bg-zd-active;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    text-wrap: balance;
+  }
+}
+
+/* Page transition animations */
+@keyframes pageSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideInFromRight {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOutToRight {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+/* Animation utility classes */
+.page-fade-in {
+  animation: pageSlideIn 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.page-loading {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+.drawer-enter {
+  animation: slideInFromRight 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.drawer-exit {
+  animation: slideOutToRight 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.fade-in-animation {
+  animation: fadeIn 0.3s ease-in-out forwards;
+}
+
+/* Body opacity transitions during page navigation */
+.body-page-loading {
+  opacity: 0.3;
+  transition: none; /* Instant darkening for immediate feedback */
+}
+
+.body-page-loaded {
+  opacity: 1;
+  transition: none; /* Instant return to full opacity */
+}
+
+/* Hide scrollbar for carousel but keep scroll functionality */
+.scrollbar-hide {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}
+
+/* TOC (Table of Contents) Styles - migrated from Gatsby article-page-layout.module.css */
+.zd-toc-pointer {
+  margin-top: var(--zd-spacing-vgap-lg);
+}
+
+.zd-toc-pointer + ul {
+  padding-top: var(--zd-spacing-vgap-sm);
+  margin-bottom: var(--zd-spacing-vgap-sm);
+  padding-right: 50px;
+  border: 1px dashed var(--zd-color-white);
+  border-left-width: 0;
+  border-right-width: 0;
+  border-bottom-width: 0;
+  list-style: none;
+  padding-left: 0;
+}
+
+@media (min-width: 740px) {
+  .zd-toc-pointer + ul {
+    padding-top: var(--zd-spacing-vgap-md);
+    padding-right: 60px;
+  }
+}
+
+@media (min-width: 980px) {
+  .zd-toc-pointer + ul {
+    padding-right: var(--zd-spacing-hgap-md);
+    border-width: 1px;
+    padding-left: var(--zd-spacing-hgap-md);
+  }
+}
+
+.zd-toc-pointer + ul li {
+  background: url(/svgs/arrow-down.svg) no-repeat 0 0.4em;
+  background-size: 20px 20px;
+  padding-left: 28px;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import './globals.css';
 
 export const metadata: Metadata = {
   title: 'OXI ONE MKII Manual',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,11 @@
 export default function Home() {
   return (
-    <main>
-      <h1>OXI ONE MKII Manual</h1>
-      <p>Project setup complete. Next.js is working!</p>
+    <main className="p-hgap-md">
+      <h1 className="text-3xl mb-vgap-md">OXI ONE MKII Manual</h1>
+      <p className="text-base mb-vgap-sm">Project setup complete. Next.js is working!</p>
+      <div className="bg-zd-gray2 p-hgap-sm rounded-md">
+        <p className="text-zd-white">Testing Zudo Design System</p>
+      </div>
     </main>
   );
 }

--- a/doc/docs/inbox/design-system.md
+++ b/doc/docs/inbox/design-system.md
@@ -93,14 +93,20 @@ Avoid Tailwind's default numeric classes - these are **not** design system token
 
 ### Configuration Files
 
-1. **`/src/styles/global.css`** - Contains all design system definitions:
+1. **`/app/globals.css`** - Contains all design system definitions:
+
 - `:root` variables - Zudo Design System token definitions (--zd-\*)
 - `@theme` block - Maps Zudo tokens to Tailwind theme variables (disables Tailwind defaults by only defining custom tokens)
 
-2. **`/tailwind.config.js`** - Minimal configuration:
+2. **`/tailwind.config.cjs`** - Minimal configuration:
+
 - Content paths for Tailwind to scan
 - Custom plugins only
-- NO theme configuration (moved to global.css)
+- NO theme configuration (moved to globals.css)
+
+3. **`/postcss.config.cjs`** - PostCSS configuration:
+
+- Tailwind CSS v4 PostCSS plugin only
 
 ### How It Works
 
@@ -218,29 +224,29 @@ When the design requires a specific value that doesn't match the vgap/hgap scale
 
 #### Horizontal Gaps (hgap)
 
-| Class | Value | Use Case |
-|-------|-------|----------|
-| `hgap-2xs` | 5px | Minimal horizontal spacing |
-| `hgap-xs` | 12px | Small gaps between elements |
-| `hgap-sm` | 20px | Default padding/margins |
-| `hgap-md` | 40px | Section spacing |
-| `hgap-md-x2` | 80px | Large section spacing |
-| `hgap-lg` | 60px | Major layout divisions |
-| `hgap-lg-x2` | 120px | Extra large divisions |
-| `hgap-xl` | 100px | Page margins |
-| `hgap-2xl` | 250px | Maximum spacing |
+| Class        | Value | Use Case                    |
+| ------------ | ----- | --------------------------- |
+| `hgap-2xs`   | 5px   | Minimal horizontal spacing  |
+| `hgap-xs`    | 12px  | Small gaps between elements |
+| `hgap-sm`    | 20px  | Default padding/margins     |
+| `hgap-md`    | 40px  | Section spacing             |
+| `hgap-md-x2` | 80px  | Large section spacing       |
+| `hgap-lg`    | 60px  | Major layout divisions      |
+| `hgap-lg-x2` | 120px | Extra large divisions       |
+| `hgap-xl`    | 100px | Page margins                |
+| `hgap-2xl`   | 250px | Maximum spacing             |
 
 #### Vertical Gaps (vgap)
 
-| Class | Value | Use Case |
-|-------|-------|----------|
-| `vgap-2xs` | 4px | Minimal vertical spacing |
-| `vgap-xs` | 8px | Tight vertical spacing |
-| `vgap-sm` | 20px | Default vertical gaps |
-| `vgap-md` | 35px | Section spacing |
-| `vgap-lg` | 50px | Major sections |
-| `vgap-xl` | 65px | Large vertical spacing |
-| `vgap-2xl` | 80px | Maximum vertical spacing |
+| Class      | Value | Use Case                 |
+| ---------- | ----- | ------------------------ |
+| `vgap-2xs` | 4px   | Minimal vertical spacing |
+| `vgap-xs`  | 8px   | Tight vertical spacing   |
+| `vgap-sm`  | 20px  | Default vertical gaps    |
+| `vgap-md`  | 35px  | Section spacing          |
+| `vgap-lg`  | 50px  | Major sections           |
+| `vgap-xl`  | 65px  | Large vertical spacing   |
+| `vgap-2xl` | 80px  | Maximum vertical spacing |
 
 ### Common Patterns
 
@@ -276,29 +282,33 @@ The Zudo Design System includes a custom color palette defined as CSS variables:
 /* Colors */
 --zd-color-black: rgb(28, 25, 23);
 --zd-color-white: rgb(214, 211, 209);
---zd-color-link: #d97706;
+--zd-color-link: #fff; /* White with text-shadow for visibility */
 --zd-color-active: #713f12;
 --zd-color-gray: rgb(120, 113, 108);
 --zd-color-gray2: #201f1f;
+--zd-color-strong: #d97706; /* Orange/amber for strong text emphasis */
 --zd-color-notify: #22c55e;
 --zd-color-error: #f43f5e;
 --zd-color-debug: #ff0000;
 --zd-color-price: #fbbf24;
+--zd-color-outline: #ea580c; /* Focus/active outlines */
 ```
 
 ### Color Usage
 
-| Color | Class | Use Case |
-|-------|-------|----------|
-| Black | `bg-zd-black`, `text-zd-black` | Backgrounds, primary text |
-| White | `bg-zd-white`, `text-zd-white` | Light backgrounds, body text |
-| Gray | `bg-zd-gray`, `text-zd-gray` | Secondary elements |
-| Gray2 | `bg-zd-gray2` | Dark backgrounds |
-| Link | `text-zd-link` | Links, CTAs |
-| Active | `bg-zd-active` | Active/pressed states |
-| Notify | `text-zd-notify` | Success messages |
-| Error | `text-zd-error` | Error messages |
-| Price | `text-zd-price` | Price displays |
+| Color   | Class                          | Use Case                       |
+| ------- | ------------------------------ | ------------------------------ |
+| Black   | `bg-zd-black`, `text-zd-black` | Backgrounds, primary text      |
+| White   | `bg-zd-white`, `text-zd-white` | Light backgrounds, body text   |
+| Gray    | `bg-zd-gray`, `text-zd-gray`   | Secondary elements             |
+| Gray2   | `bg-zd-gray2`                  | Dark backgrounds               |
+| Link    | `text-zd-link`                 | Links (white with text-shadow) |
+| Strong  | `text-zd-strong`               | Strong text emphasis           |
+| Active  | `bg-zd-active`                 | Active/pressed states          |
+| Notify  | `text-zd-notify`               | Success messages               |
+| Error   | `text-zd-error`                | Error messages                 |
+| Price   | `text-zd-price`                | Price displays                 |
+| Outline | `outline-zd-outline`           | Focus/active outlines          |
 
 ## Typography
 
@@ -308,23 +318,23 @@ The project uses a combined font-size and line-height system for consistent typo
 
 ```css
 /* Font size / line height combinations */
---zd-font-xs-size: 1rem;           /* 10px */
+--zd-font-xs-size: 1rem; /* 10px */
 --zd-font-xs-lineHeight: 1.4;
---zd-font-sm-size: 1.1rem;         /* 11px */
+--zd-font-sm-size: 1.1rem; /* 11px */
 --zd-font-sm-lineHeight: 1.5;
---zd-font-base-size: 1.4rem;       /* 14px */
+--zd-font-base-size: 1.4rem; /* 14px */
 --zd-font-base-lineHeight: 1.7;
---zd-font-lg-size: 1.6rem;         /* 16px */
+--zd-font-lg-size: 1.6rem; /* 16px */
 --zd-font-lg-lineHeight: 1.5;
---zd-font-xl-size: 1.9rem;         /* 19px */
+--zd-font-xl-size: 1.9rem; /* 19px */
 --zd-font-xl-lineHeight: 1.4;
---zd-font-2xl-size: 2.8rem;        /* 28px */
+--zd-font-2xl-size: 2.8rem; /* 28px */
 --zd-font-2xl-lineHeight: 1.35;
---zd-font-3xl-size: 3.2rem;        /* 32px */
+--zd-font-3xl-size: 3.2rem; /* 32px */
 --zd-font-3xl-lineHeight: 1.3;
---zd-font-4xl-size: 4rem;          /* 40px */
+--zd-font-4xl-size: 4rem; /* 40px */
 --zd-font-4xl-lineHeight: 1.3;
---zd-font-5xl-size: 4.8rem;        /* 48px */
+--zd-font-5xl-size: 4.8rem; /* 48px */
 --zd-font-5xl-lineHeight: 1.3;
 ```
 
@@ -484,9 +494,7 @@ Due to wildcard resets in the `@theme` block, the following Tailwind default uti
 
 ```jsx
 // ❌ This code will FAIL to build:
-<div className="px-4 bg-gray-500 text-sm">
-  Content
-</div>
+<div className="px-4 bg-gray-500 text-sm">Content</div>
 
 // Error: The utility `px-4` does not exist in your theme.
 // Error: The utility `bg-gray-500` does not exist in your theme.
@@ -531,6 +539,7 @@ This strict enforcement ensures design consistency across the entire application
 4. Only custom tokens are available - Tailwind defaults are completely removed
 
 **Key Syntax:**
+
 ```css
 @theme {
   /* STEP 1: Reset all Tailwind defaults using wildcard patterns */
@@ -561,5 +570,6 @@ This strict enforcement ensures design consistency across the entire application
 
 ## Related Files
 
-- **All design system configuration**: `/src/styles/global.css`
-- **Minimal Tailwind config**: `/tailwind.config.js` (content paths only)
+- **All design system configuration**: `/app/globals.css`
+- **Minimal Tailwind config**: `/tailwind.config.cjs` (content paths only)
+- **PostCSS config**: `/postcss.config.cjs` (Tailwind CSS v4 plugin)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -51,6 +52,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "prettier": "^3.2.5",
+    "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@tailwindcss/postcss':
+        specifier: ^4.1.18
+        version: 4.1.18
       '@types/node':
         specifier: ^22
         version: 22.19.3
@@ -32,22 +35,22 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.51.0
-        version: 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.51.0
-        version: 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.2(jiti@1.21.7)
+        version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: ^16.1.1
-        version: 16.1.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 16.1.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-react:
         specifier: ^7.37.5
-        version: 7.37.5(eslint@9.39.2(jiti@1.21.7))
+        version: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
-        version: 7.0.1(eslint@9.39.2(jiti@1.21.7))
+        version: 7.0.1(eslint@9.39.2(jiti@2.6.1))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -57,6 +60,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.7.4
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -157,10 +163,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^1.2.0
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.3)(terser@5.44.1))
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1))
       vitest:
         specifier: ^1.2.0
-        version: 1.6.1(@types/node@22.19.3)(terser@5.44.1)
+        version: 1.6.1(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1)
 
 packages:
 
@@ -262,6 +268,10 @@ packages:
   '@algolia/requester-node-http@5.46.2':
     resolution: {integrity: sha512-ciPihkletp7ttweJ8Zt+GukSVLp2ANJHU+9ttiSxsJZThXc4Y2yJ8HGVWesW5jN1zrsZsezN71KrMx/iZsOYpg==}
     engines: {node: '>= 14.0.0'}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -2243,6 +2253,94 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@tailwindcss/node@4.1.18':
+    resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    resolution: {integrity: sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    resolution: {integrity: sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    resolution: {integrity: sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    resolution: {integrity: sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    resolution: {integrity: sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    resolution: {integrity: sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    resolution: {integrity: sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    resolution: {integrity: sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.18':
+    resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/postcss@4.1.18':
+    resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -4899,6 +4997,10 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
 
@@ -5007,6 +5109,76 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lightningcss-android-arm64@1.30.2:
+    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.30.2:
+    resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.2:
+    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.2:
+    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.2:
+    resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.2:
+    resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -6881,6 +7053,9 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  tailwindcss@4.1.18:
+    resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
@@ -7602,6 +7777,8 @@ snapshots:
   '@algolia/requester-node-http@5.46.2':
     dependencies:
       '@algolia/client-common': 5.46.2
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -9637,9 +9814,9 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@1.21.7))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -10263,6 +10440,75 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@tailwindcss/node@4.1.18':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.18.4
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.1.18
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.18':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-x64': 4.1.18
+      '@tailwindcss/oxide-freebsd-x64': 4.1.18
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.18
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.18
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.18
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
+
+  '@tailwindcss/postcss@4.1.18':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      postcss: 8.5.6
+      tailwindcss: 4.1.18
+
   '@trysound/sax@0.2.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -10570,15 +10816,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.51.0
-      '@typescript-eslint/type-utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.51.0
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.3.0(typescript@5.9.3)
@@ -10586,14 +10832,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.51.0
       '@typescript-eslint/types': 8.51.0
       '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.51.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -10616,13 +10862,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.51.0
       '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       ts-api-utils: 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10645,13 +10891,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.51.0
       '@typescript-eslint/types': 8.51.0
       '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -10724,7 +10970,7 @@ snapshots:
 
   '@vercel/oidc@3.0.5': {}
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@22.19.3)(terser@5.44.1))':
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -10739,7 +10985,7 @@ snapshots:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@22.19.3)(terser@5.44.1)
+      vitest: 1.6.1(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11921,8 +12167,7 @@ snapshots:
 
   destroy@1.2.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node@2.1.0: {}
 
@@ -12207,18 +12452,18 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.1.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
+  eslint-config-next@16.1.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.1
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
-      typescript-eslint: 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      typescript-eslint: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12235,33 +12480,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12270,9 +12515,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12284,13 +12529,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -12300,7 +12545,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -12309,18 +12554,18 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       hermes-parser: 0.25.1
       zod: 4.3.4
       zod-validation-error: 4.0.2(zod@4.3.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -12328,7 +12573,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.2
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -12356,9 +12601,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.2(jiti@1.21.7):
+  eslint@9.39.2(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
@@ -12393,7 +12638,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 1.21.7
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13406,6 +13651,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jiti@2.6.1: {}
+
   joi@17.13.3:
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -13511,6 +13758,55 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightningcss-android-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.2:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss@1.30.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.30.2
+      lightningcss-darwin-arm64: 1.30.2
+      lightningcss-darwin-x64: 1.30.2
+      lightningcss-freebsd-x64: 1.30.2
+      lightningcss-linux-arm-gnueabihf: 1.30.2
+      lightningcss-linux-arm64-gnu: 1.30.2
+      lightningcss-linux-arm64-musl: 1.30.2
+      lightningcss-linux-x64-gnu: 1.30.2
+      lightningcss-linux-x64-musl: 1.30.2
+      lightningcss-win32-arm64-msvc: 1.30.2
+      lightningcss-win32-x64-msvc: 1.30.2
 
   lilconfig@3.1.3: {}
 
@@ -15952,6 +16248,8 @@ snapshots:
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  tailwindcss@4.1.18: {}
+
   tapable@2.3.0: {}
 
   terser-webpack-plugin@5.3.16(webpack@5.104.1):
@@ -16088,13 +16386,13 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
+  typescript-eslint@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -16267,13 +16565,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@1.6.1(@types/node@22.19.3)(terser@5.44.1):
+  vite-node@1.6.1(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.21(@types/node@22.19.3)(terser@5.44.1)
+      vite: 5.4.21(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16285,7 +16583,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21(@types/node@22.19.3)(terser@5.44.1):
+  vite@5.4.21(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -16293,9 +16591,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.3
       fsevents: 2.3.3
+      lightningcss: 1.30.2
       terser: 5.44.1
 
-  vitest@1.6.1(@types/node@22.19.3)(terser@5.44.1):
+  vitest@1.6.1(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -16314,8 +16613,8 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.21(@types/node@22.19.3)(terser@5.44.1)
-      vite-node: 1.6.1(@types/node@22.19.3)(terser@5.44.1)
+      vite: 5.4.21(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1)
+      vite-node: 1.6.1(@types/node@22.19.3)(lightningcss@1.30.2)(terser@5.44.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.3

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,25 @@
+/** @type {import('tailwindcss').Config} */
+
+/**
+ * Tailwind Configuration - Minimal Setup
+ *
+ * All theme configuration (spacing, colors, typography, etc.) has been moved
+ * to the @theme block in app/globals.css.
+ *
+ * This file only contains:
+ * - Content paths for Tailwind to scan
+ * - Custom plugins
+ *
+ * The @theme reset directive in globals.css disables all Tailwind defaults,
+ * ensuring only Zudo Design System tokens are available.
+ */
+
+module.exports = {
+  content: [
+    './app/**/*.{js,jsx,ts,tsx,mdx}',
+    './components/**/*.{js,jsx,ts,tsx,mdx}',
+    './lib/**/*.{js,jsx,ts,tsx,mdx}',
+    './*.js',
+  ],
+  plugins: [],
+};


### PR DESCRIPTION
## Summary

Implements the Zudo Design System using Tailwind CSS v4 with a strict, token-based approach that disables all Tailwind defaults.

## Changes

### Configuration Files
- ✅ Created `tailwind.config.cjs` - Minimal configuration with content paths only
- ✅ Created `postcss.config.cjs` - Tailwind CSS v4 PostCSS plugin
- ✅ Both use `.cjs` extension for CommonJS compatibility with `"type": "module"`

### Design System Implementation
- ✅ Created `/app/globals.css` (526 lines) with complete Zudo Design System
- ✅ Imported in `/app/layout.tsx` for global application
- ✅ Updated test page with design system utilities

### CSS Variables & Theme
- ✅ **:root variables**: All Zudo tokens (--zd-*)
  - Colors: black, white, gray, gray2, link, strong, active, notify, error, price, outline
  - Spacing: hgap-* (horizontal), vgap-* (vertical)
  - Typography: font sizes with integrated line heights
  - Font families with Japanese fallbacks
  - Breakpoints, shadows, borders, etc.

- ✅ **@theme block**: Wildcard resets + custom tokens
  - Disables ALL Tailwind defaults via `--namespace-*: initial`
  - Only Zudo Design System tokens available
  - Strict mode enforced at build time

### Custom Utilities
- ✅ Gradients: `zd-gradient-black-to-transparent`, `zd-gradient-white-to-transparent`
- ✅ Links: `zd-invert-color-link`, `zd-invert-color-link--focus`, `zd-invert-color-link-inline`
- ✅ Text: `text-shadow-md`, `text-shadow-none`
- ✅ Layout: `clearfix`, `zd-hash`

### Documentation
- ✅ Updated `/doc/docs/inbox/design-system.md`
  - Corrected file paths for this project
  - Updated color palette documentation
  - Added new colors (strong, outline)

### Dependencies
- ✅ Installed `tailwindcss@^4.1.18`
- ✅ Installed `@tailwindcss/postcss@^4.1.18`

## Design System Features

### ✨ All Tailwind Defaults Disabled
- Using `--spacing-*: initial`, `--color-*: initial`, etc. to reset ALL defaults
- Only Zudo tokens available: `hgap-*`, `vgap-*`, `zd-black`, `zd-white`, etc.
- Build errors guide developers to correct tokens

### 🎨 Semantic Spacing
- `hgap-*`: Horizontal gaps (5px to 250px)
- `vgap-*`: Vertical gaps (4px to 80px)
- No numeric classes like `p-4`, `m-8`

### 🌙 Dark Theme
- Default dark theme with custom background pattern
- Comprehensive color system for dark UI

### 🇯🇵 Japanese Font Support
- Font stacks with Japanese fallbacks
- Noto Sans, Futura, and system fonts

## Testing

- ✅ Tailwind CSS v4 compiles successfully
- ✅ All Zudo tokens work as utilities
- ✅ Design system applied to test page
- ✅ Code properly formatted

## Files Changed

- `app/globals.css` - New design system file (526 lines)
- `tailwind.config.cjs` - New Tailwind configuration
- `postcss.config.cjs` - New PostCSS configuration
- `app/layout.tsx` - Import globals.css
- `app/page.tsx` - Test design system utilities
- `doc/docs/inbox/design-system.md` - Updated documentation
- `package.json` - Added Tailwind dependencies
- `pnpm-lock.yaml` - Updated lock file

## Next Steps

After merging, all components can use:
- Spacing: `px-hgap-md`, `py-vgap-sm`, etc.
- Colors: `bg-zd-black`, `text-zd-white`, etc.
- Typography: `text-3xl`, `text-base`, etc.
- Custom utilities: `zd-invert-color-link`, `text-shadow-md`, etc.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)