### PR TITLE
Phase 1: Foundation - Shared Config Resolver for Multi-PDF

### DIFF
--- a/pdf-config.json
+++ b/pdf-config.json
@@ -1,15 +1,4 @@
 {
-  "input": {
-    "pdfDirectory": "manual-pdf",
-    "pdfPattern": "*.pdf"
-  },
-  "output": {
-    "pages": "manual-pdf/pages",
-    "images": "public/manuals/oxi-one-mk2/pages",
-    "extracted": "public/manuals/oxi-one-mk2/processing/extracted",
-    "translationsDraft": "public/manuals/oxi-one-mk2/processing/translations-draft",
-    "translations": "public/manuals/oxi-one-mk2/data"
-  },
   "settings": {
     "pagesPerPart": 30,
     "imageFormat": "png",

--- a/scripts/lib/pdf-config-resolver.js
+++ b/scripts/lib/pdf-config-resolver.js
@@ -1,0 +1,143 @@
+/**
+ * PDF Config Resolver - Shared utility for multi-PDF support
+ *
+ * Parses CLI args, validates slug, finds source PDF, and computes all paths
+ * from the slug to support multiple manuals in the same codebase.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { glob } from 'glob';
+
+/**
+ * Resolves manual configuration from CLI slug argument
+ *
+ * @param {string} rootDir - Root directory of the project
+ * @returns {object} Configuration object with paths and settings
+ * @throws {Error} If slug is missing, invalid, or PDF not found
+ *
+ * @example
+ * const config = resolveManualConfig(process.cwd());
+ * // Returns:
+ * // {
+ * //   slug: 'oxi-one-mk2',
+ * //   sourcePdf: '/path/to/manual-pdf/oxi-one-mk2/OXI-ONE-MKII.pdf',
+ * //   input: { pdfDirectory: 'manual-pdf/oxi-one-mk2', pdfPattern: '*.pdf' },
+ * //   output: { pages: '...', images: '...', ... },
+ * //   settings: { pagesPerPart: 30, ... }
+ * // }
+ */
+export function resolveManualConfig(rootDir) {
+  // Parse CLI args to find --slug argument
+  const args = process.argv.slice(2);
+  const slugIndex = args.indexOf('--slug');
+
+  if (slugIndex === -1 || !args[slugIndex + 1]) {
+    throw new Error(
+      '❌ Missing required --slug argument\n\n' +
+      'Usage: node script.js --slug <manual-slug>\n' +
+      'Example: node script.js --slug oxi-one-mk2'
+    );
+  }
+
+  const slug = args[slugIndex + 1];
+
+  // Validate slug format (prevent path traversal attacks)
+  const slugPattern = /^[a-z0-9-]+$/i;
+
+  if (!slugPattern.test(slug)) {
+    throw new Error(
+      `❌ Invalid slug format: "${slug}"\n\n` +
+      'Slug must only contain:\n' +
+      '  - Letters (a-z, A-Z)\n' +
+      '  - Numbers (0-9)\n' +
+      '  - Hyphens (-)\n\n' +
+      'Path traversal patterns (../, ./, etc.) are not allowed.\n\n' +
+      'Valid examples:\n' +
+      '  ✅ oxi-one-mk2\n' +
+      '  ✅ manual-v2\n' +
+      '  ✅ ProductName-2024\n\n' +
+      'Invalid examples:\n' +
+      '  ❌ ../etc/passwd\n' +
+      '  ❌ manual/v2\n' +
+      '  ❌ .hidden'
+    );
+  }
+
+  // Load settings from pdf-config.json
+  const configPath = join(rootDir, 'pdf-config.json');
+
+  if (!existsSync(configPath)) {
+    throw new Error(
+      `❌ Configuration file not found: ${configPath}\n\n` +
+      'Please ensure pdf-config.json exists in the project root.'
+    );
+  }
+
+  let config;
+  try {
+    config = JSON.parse(readFileSync(configPath, 'utf-8'));
+  } catch (error) {
+    throw new Error(
+      `❌ Failed to parse pdf-config.json: ${error.message}\n\n` +
+      'Please ensure the file contains valid JSON.'
+    );
+  }
+
+  // Validate that config has required settings
+  if (!config.settings) {
+    throw new Error(
+      '❌ Invalid pdf-config.json: missing "settings" section\n\n' +
+      'Please ensure pdf-config.json has a "settings" object.'
+    );
+  }
+
+  // Find source PDF in manual-pdf/{slug}/
+  const pdfDir = join(rootDir, 'manual-pdf', slug);
+  const pdfPattern = join(pdfDir, '*.pdf');
+  const pdfFiles = glob.sync(pdfPattern);
+
+  if (pdfFiles.length === 0) {
+    throw new Error(
+      `❌ No PDF file found in: ${pdfDir}\n\n` +
+      `Please ensure your PDF is located at:\n` +
+      `  manual-pdf/${slug}/<filename>.pdf\n\n` +
+      `Example:\n` +
+      `  manual-pdf/${slug}/Manual.pdf`
+    );
+  }
+
+  const sourcePdf = pdfFiles[0];
+
+  if (pdfFiles.length > 1) {
+    console.warn(
+      `⚠️  Multiple PDF files found in ${pdfDir}\n` +
+      `   Using: ${sourcePdf}\n` +
+      `   Other files: ${pdfFiles.slice(1).join(', ')}`
+    );
+  }
+
+  // Compute all paths from slug
+  const paths = {
+    slug,
+    sourcePdf,
+    input: {
+      pdfDirectory: join('manual-pdf', slug),
+      pdfPattern: '*.pdf'
+    },
+    output: {
+      pages: join('manual-pdf', slug, 'pages'),
+      images: join('public', 'manuals', slug, 'pages'),
+      extracted: join('public', 'manuals', slug, 'processing', 'extracted'),
+      translationsDraft: join('public', 'manuals', slug, 'processing', 'translations-draft'),
+      translations: join('public', 'manuals', slug, 'data')
+    }
+  };
+
+  // Return merged configuration
+  return {
+    ...paths,
+    settings: config.settings,
+    partConfig: config.partConfig
+  };
+}


### PR DESCRIPTION
## Phase 1: Foundation - Shared Config Resolver for Multi-PDF

Part of #31 - Multi-PDF Support Implementation

### Summary

This PR implements the foundation for multi-PDF support by creating a shared config resolver that allows the system to work with multiple manuals instead of being hardcoded to `oxi-one-mk2`.

### Changes

#### 1. Created Shared Config Resolver
**File**: `scripts/lib/pdf-config-resolver.js`

- Parses CLI `--slug` argument from `process.argv`
- Validates slug format using regex `/^[a-z0-9-]+$/i` to prevent path traversal
- Finds source PDF in `/manual-pdf/{slug}/` directory
- Computes all output paths dynamically from slug
- Provides clear, helpful error messages
- Merges with settings from `pdf-config.json`

#### 2. Updated pdf-config.json
- Removed hardcoded `input` section
- Removed hardcoded `output` section with `oxi-one-mk2` paths
- Kept only slug-agnostic `settings` and `partConfig` sections

#### 3. Directory Restructuring
- Moved PDF from `manual-pdf/OXI ONE MKII Manual.pdf` to `manual-pdf/oxi-one-mk2/`
- Ready for multi-PDF architecture

### Testing

All test cases passed:
- ✅ **Valid slug** (`--slug oxi-one-mk2`): Works correctly, returns proper config
- ✅ **Invalid slug** (`--slug ../etc/passwd`): Rejected with clear error message
- ✅ **Missing slug**: Shows helpful usage message

### Data Preservation
- ✅ All existing `oxi-one-mk2` data preserved:
  - 11 JSON files (manifest + 10 parts)
  - 274 PNG page images
  - Directory structure intact

### Security
- Path traversal prevention with regex validation
- Clear error messages guide users on valid slug format

### Next Steps
Phase 2 will update PDF processing scripts to use `resolveManualConfig()` and replace hardcoded paths.

### Related Issues
- Parent: #31 Multi-PDF Support Implementation
- Issue: #32 Phase 1: Foundation - Shared Config Resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)