### PR TITLE
refactor: Phase 2 - Update PDF Scripts for Multi-Manual Support

### DIFF
--- a/scripts/pdf-build.js
+++ b/scripts/pdf-build.js
@@ -4,23 +4,25 @@
  * PDF Build Script - Page by Page
  * Combines individual page translations into part JSON files
  *
- * Input: data/translations-draft/page-*.json
- * Output: data/translations/part-01.json, part-02.json, etc.
+ * Input: public/manuals/{slug}/processing/translations-draft/page-*.json
+ * Output: public/manuals/{slug}/data/part-01.json, part-02.json, etc.
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveManualConfig } from './lib/pdf-config-resolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 
-// Load configuration
-const config = JSON.parse(readFileSync(join(ROOT_DIR, 'pdf-config.json'), 'utf-8'));
+// Load configuration from shared resolver
+const config = resolveManualConfig(ROOT_DIR);
 
 console.log('🔨 PDF Build Script (Page by Page)');
 console.log('='.repeat(50));
+console.log(`📦 Manual: ${config.slug}`);
 console.log('');
 
 const draftsDir = join(ROOT_DIR, config.output.translationsDraft);
@@ -92,7 +94,7 @@ for (let partIndex = 0; partIndex < partCount; partIndex++) {
 
       return {
         pageNum: pageNum,
-        image: `/manuals/oxi-one-mk2/pages/page-${String(pageNum).padStart(3, '0')}.png`,
+        image: `/manuals/${config.slug}/pages/page-${String(pageNum).padStart(3, '0')}.png`,
         title: `Page ${pageNum}`,
         sectionName: null,
         translation: pageData.translation || '',

--- a/scripts/pdf-clean.js
+++ b/scripts/pdf-clean.js
@@ -5,41 +5,43 @@
  * Removes all generated files before reprocessing
  *
  * This script deletes:
- * - public/manuals/oxi-one-mk2/pages/* (rendered images)
- * - public/manuals/oxi-one-mk2/processing/extracted/* (extracted text)
- * - public/manuals/oxi-one-mk2/processing/translations-draft/* (translation drafts)
- * - public/manuals/oxi-one-mk2/data/* (final JSON files)
- * - manual-pdf/pages/* (page PDFs)
+ * - public/manuals/{slug}/pages/* (rendered images)
+ * - public/manuals/{slug}/processing/extracted/* (extracted text)
+ * - public/manuals/{slug}/processing/translations-draft/* (translation drafts)
+ * - public/manuals/{slug}/data/* (final JSON files)
+ * - manual-pdf/{slug}/pages/* (page PDFs)
  *
  * Keeps:
- * - Source PDF in manual-pdf/
+ * - Source PDF in manual-pdf/{slug}/
  * - Configuration files
  */
 
 import { rmSync, mkdirSync, existsSync, readdirSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveManualConfig } from './lib/pdf-config-resolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 
-// Load configuration
-const config = JSON.parse(
-  await import('fs').then((fs) => fs.readFileSync(join(ROOT_DIR, 'pdf-config.json'), 'utf-8')),
-);
+// Load configuration from shared resolver
+const config = resolveManualConfig(ROOT_DIR);
 
 console.log('🧹 PDF Clean Script');
 console.log('='.repeat(50));
+console.log(`📦 Manual: ${config.slug}`);
 console.log('');
 console.log('⚠️  This will remove all generated files from PDF processing:');
-console.log('   - Rendered images (public/manuals/oxi-one-mk2/pages/)');
-console.log('   - Extracted text (public/manuals/oxi-one-mk2/processing/extracted/)');
-console.log('   - Translation drafts (public/manuals/oxi-one-mk2/processing/translations-draft/)');
-console.log('   - Final translations (public/manuals/oxi-one-mk2/data/)');
-console.log('   - Page PDFs (manual-pdf/pages/)');
+console.log(`   - Rendered images (public/manuals/${config.slug}/pages/)`);
+console.log(`   - Extracted text (public/manuals/${config.slug}/processing/extracted/)`);
+console.log(
+  `   - Translation drafts (public/manuals/${config.slug}/processing/translations-draft/)`,
+);
+console.log(`   - Final translations (public/manuals/${config.slug}/data/)`);
+console.log(`   - Page PDFs (manual-pdf/${config.slug}/pages/)`);
 console.log('');
-console.log('   Source PDFs in manual-pdf/ will be kept.');
+console.log(`   Source PDFs in manual-pdf/${config.slug}/ will be kept.`);
 console.log('');
 
 /**

--- a/scripts/pdf-extract-text.js
+++ b/scripts/pdf-extract-text.js
@@ -4,14 +4,15 @@
  * PDF Text Extraction Script - Page by Page
  * Extracts text from individual page PDFs
  *
- * Input: manual-pdf/pages/page-*.pdf
- * Output: data/extracted/page-001.txt, page-002.txt, etc.
+ * Input: manual-pdf/{slug}/pages/page-*.pdf
+ * Output: public/manuals/{slug}/processing/extracted/page-001.txt, page-002.txt, etc.
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import { resolveManualConfig } from './lib/pdf-config-resolver.js';
 
 const require = createRequire(import.meta.url);
 const { PDFParse } = require('pdf-parse');
@@ -20,8 +21,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 
-// Load configuration
-const config = JSON.parse(readFileSync(join(ROOT_DIR, 'pdf-config.json'), 'utf-8'));
+// Load configuration from shared resolver
+const config = resolveManualConfig(ROOT_DIR);
 
 async function extractTextFromPdf(pdfPath) {
   // pdf-parse v2 API
@@ -40,6 +41,7 @@ async function extractTextFromPdf(pdfPath) {
 async function extractAllText() {
   console.log('📝 PDF Text Extraction Script (Page by Page)');
   console.log('='.repeat(50));
+  console.log(`📦 Manual: ${config.slug}`);
 
   const pagesDir = join(ROOT_DIR, config.output.pages);
   const outputDir = join(ROOT_DIR, config.output.extracted);

--- a/scripts/pdf-manifest.js
+++ b/scripts/pdf-manifest.js
@@ -4,8 +4,8 @@
  * PDF Manifest Script
  * Generates master manifest.json from all part files
  *
- * Input: data/translations/part-*.json
- * Output: data/translations/manifest.json
+ * Input: public/manuals/{slug}/data/part-*.json
+ * Output: public/manuals/{slug}/data/manifest.json
  *
  * This script:
  * - Scans all part JSON files
@@ -15,18 +15,34 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveManualConfig } from './lib/pdf-config-resolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 
-// Load configuration
-const config = JSON.parse(readFileSync(join(ROOT_DIR, 'pdf-config.json'), 'utf-8'));
+// Load configuration from shared resolver
+const config = resolveManualConfig(ROOT_DIR);
+
+/**
+ * Convert slug to manual title
+ * @param {string} slug - Manual slug (e.g., 'oxi-one-mk2')
+ * @returns {string} Manual title (e.g., 'OXI ONE MKII Manual')
+ */
+function slugToTitle(slug) {
+  const titleMap = {
+    'oxi-one-mk2': 'OXI ONE MKII Manual',
+    'oxi-coral': 'OXI Coral Manual',
+  };
+
+  return titleMap[slug] || slug.toUpperCase().replace(/-/g, ' ') + ' Manual';
+}
 
 console.log('📋 PDF Manifest Generator');
 console.log('='.repeat(50));
+console.log(`📦 Manual: ${config.slug}`);
 console.log('');
 
 const translationsDir = join(ROOT_DIR, config.output.translations);
@@ -131,13 +147,13 @@ function buildManifest() {
 
   // Build manifest
   const manifest = {
-    title: 'OXI ONE MKII Manual',
+    title: slugToTitle(config.slug),
     version: '1.0.0',
     totalPages: totalPages,
     contentPages: totalContentPages,
     lastUpdated: new Date().toISOString(),
     source: {
-      filename: 'OXI-ONE-MKII-Manual.pdf',
+      filename: basename(config.sourcePdf),
       processedAt: earliestProcessedAt
         ? earliestProcessedAt.toISOString()
         : new Date().toISOString(),

--- a/scripts/pdf-render-pages.js
+++ b/scripts/pdf-render-pages.js
@@ -4,25 +4,27 @@
  * PDF Page Rendering Script - Page by Page
  * Renders individual page PDFs to PNG images
  *
- * Input: manual-pdf/pages/page-*.pdf
- * Output: public/manual/pages/page-001.png, page-002.png, etc.
+ * Input: manual-pdf/{slug}/pages/page-*.pdf
+ * Output: public/manuals/{slug}/pages/page-001.png, page-002.png, etc.
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { pdfToPng } from 'pdf-to-png-converter';
+import { resolveManualConfig } from './lib/pdf-config-resolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 
-// Load configuration
-const config = JSON.parse(readFileSync(join(ROOT_DIR, 'pdf-config.json'), 'utf-8'));
+// Load configuration from shared resolver
+const config = resolveManualConfig(ROOT_DIR);
 
 async function renderPdfPages() {
   console.log('🖼️  PDF Page Rendering Script (Page by Page)');
   console.log('='.repeat(50));
+  console.log(`📦 Manual: ${config.slug}`);
 
   const pagesDir = join(ROOT_DIR, config.output.pages);
   const outputDir = join(ROOT_DIR, config.output.images);

--- a/scripts/pdf-split.js
+++ b/scripts/pdf-split.js
@@ -4,49 +4,31 @@
  * PDF Split Script - Page by Page
  * Splits PDF into individual page files
  *
- * Input: manual-pdf/*.pdf
- * Output: manual-pdf/pages/page-001.pdf, page-002.pdf, etc.
+ * Input: manual-pdf/{slug}/*.pdf
+ * Output: manual-pdf/{slug}/pages/page-001.pdf, page-002.pdf, etc.
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { PDFDocument } from 'pdf-lib';
-import { glob } from 'glob';
+import { resolveManualConfig } from './lib/pdf-config-resolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 
-// Load configuration
-const config = JSON.parse(readFileSync(join(ROOT_DIR, 'pdf-config.json'), 'utf-8'));
+// Load configuration from shared resolver
+const config = resolveManualConfig(ROOT_DIR);
 
 async function splitPDF() {
   console.log('🔪 PDF Split Script (Page by Page)');
   console.log('='.repeat(50));
-
-  // Find input PDF
-  const pdfPattern = join(ROOT_DIR, config.input.pdfDirectory, config.input.pdfPattern);
-  const pdfFiles = glob.sync(pdfPattern);
-
-  if (pdfFiles.length === 0) {
-    console.error(`❌ No PDF found matching: ${pdfPattern}`);
-    console.error(`   Please place your PDF in: ${join(ROOT_DIR, config.input.pdfDirectory)}/`);
-    process.exit(1);
-  }
-
-  const inputPdfPath = pdfFiles[0];
-
-  if (pdfFiles.length > 1) {
-    console.log(`📋 Multiple PDFs found, using: ${inputPdfPath}`);
-    console.log(`   Other files: ${pdfFiles.slice(1).join(', ')}`);
-    console.log('');
-  } else {
-    console.log(`📄 Input PDF: ${inputPdfPath}`);
-  }
+  console.log(`📦 Manual: ${config.slug}`);
+  console.log(`📄 Input PDF: ${config.sourcePdf}`);
 
   // Load PDF
-  const pdfBytes = readFileSync(inputPdfPath);
+  const pdfBytes = readFileSync(config.sourcePdf);
   const pdfDoc = await PDFDocument.load(pdfBytes);
   const totalPages = pdfDoc.getPageCount();
 

--- a/scripts/pdf-translate.js
+++ b/scripts/pdf-translate.js
@@ -4,8 +4,8 @@
  * PDF Translation Script
  * Translates extracted text using Claude Code manual-translator subagents (parallel processing)
  *
- * Input: data/extracted/part-*.txt
- * Output: data/translations-draft/part-*.json
+ * Input: public/manuals/{slug}/processing/extracted/part-*.txt
+ * Output: public/manuals/{slug}/processing/translations-draft/part-*.json
  *
  * This script uses Claude Code's Task tool to spawn manual-translator subagents.
  * It runs 4 translations in parallel to maximize throughput.
@@ -14,13 +14,14 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveManualConfig } from './lib/pdf-config-resolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 
-// Load configuration
-const config = JSON.parse(readFileSync(join(ROOT_DIR, 'pdf-config.json'), 'utf-8'));
+// Load configuration from shared resolver
+const config = resolveManualConfig(ROOT_DIR);
 
 const PARALLEL_AGENTS = 4; // Process 4 parts at a time
 


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of #33, updating all PDF processing scripts to support multi-manual architecture.

## Changes

### All Scripts Updated (7 files)
- ✅ `scripts/pdf-split.js` - Accepts `--slug` parameter, uses shared resolver
- ✅ `scripts/pdf-render-pages.js` - Dynamic paths using `config.slug`
- ✅ `scripts/pdf-extract-text.js` - Uses shared config resolver
- ✅ `scripts/pdf-translate.js` - Updated imports and paths
- ✅ `scripts/pdf-build.js` - **CRITICAL FIX**: Dynamic image paths using `config.slug`
- ✅ `scripts/pdf-manifest.js` - **CRITICAL FIX**: Slug-to-title mapping function
- ✅ `scripts/pdf-clean.js` - Dynamic console output with slug

### Critical Fixes
1. **pdf-build.js:97** - Image paths now use `/manuals/${config.slug}/pages/...` instead of hardcoded `/manuals/oxi-one-mk2/pages/...`
2. **pdf-manifest.js:150** - Title derived from slug using `slugToTitle()` function with fallback

### Key Features
- All scripts now require `--slug` parameter
- Shared config resolver eliminates code duplication
- No hardcoded `oxi-one-mk2` references remain
- Proper error handling when `--slug` is missing
- Dynamic paths support multiple manuals

## Testing

✅ Tested `pdf-split.js --slug oxi-one-mk2` - Successfully processed 272 pages
✅ Tested `pdf-clean.js --slug oxi-one-mk2` - Displays correct slug-based paths  
✅ Tested error handling - Proper error message when `--slug` is missing
✅ Tested slug-to-title mapping - Correctly maps known and unknown slugs
✅ ESLint passing
✅ Lint-staged formatting applied

## Part of

- Parent: #31 Multi-PDF Support Implementation
- Depends on: #32 (Phase 1 - Shared Config Resolver) ✅
- Enables: Phase 3 - App Routing Refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)