### PR TITLE
chore: プロジェクト名変更 + Next.js 15 scroll警告修正

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,13 +12,13 @@ const notoSans = Noto_Sans_JP({
 });
 
 export const metadata: Metadata = {
-  title: 'OXI ONE MKII Manual',
-  description: 'OXI ONE MKII Hardware Synthesizer Manual - Japanese Translation',
+  title: 'Takazudo Modular: Manuals',
+  description: 'Hardware synthesizer manuals with Japanese translations',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja">
+    <html lang="ja" data-scroll-behavior="smooth">
       <body className={notoSans.variable}>
         <Header />
         {children}

--- a/doc/docs/inbox/design-system.md
+++ b/doc/docs/inbox/design-system.md
@@ -5,7 +5,7 @@ sidebar_position: 100
 
 # Design System
 
-This document describes the Zudo Design System used in the OXI ONE MKII Manual project, including spacing conventions, color system, and typography.
+This document describes the Zudo Design System used in this project, including spacing conventions, color system, and typography.
 
 ## 🎯 Design System Philosophy
 

--- a/doc/docs/inbox/index.md
+++ b/doc/docs/inbox/index.md
@@ -6,7 +6,7 @@ pagination_prev: null
 
 # INBOX
 
-Development documentation for OXI ONE MKII Manual project.
+Development documentation for Takazudo Modular: Manuals project.
 
 ## Current Content
 
@@ -18,10 +18,10 @@ Development documentation for OXI ONE MKII Manual project.
 
 ### Project Goal
 
-Create a web-based manual viewer for the OXI ONE MKII hardware synthesizer that displays:
+Create a web-based manual viewer for hardware synthesizer manuals that displays:
 
-- 272-page manual in bilingual format
-- Original English PDF pages (rendered as PNG images at 150 DPI)
+- Multiple manuals in bilingual format
+- Original English PDF pages (rendered as PNG images at 300 DPI)
 - Japanese translations alongside each page
 - Searchable, user-friendly interface
 
@@ -35,10 +35,9 @@ Create a web-based manual viewer for the OXI ONE MKII hardware synthesizer that 
 
 ### Data Structure
 
-- **JSON format** for translation data
+- **JSON format** for translation data (pages.json per manual)
 - **Markdown/MDX** for translation content
 - **PNG images** for rendered PDF pages
-- 10 parts total (Part 01-10)
 
 ## Documentation Categories
 

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -3,9 +3,9 @@ title: Welcome
 sidebar_position: 1
 ---
 
-# OXI ONE MKII Manual Documentation
+# Takazudo Modular: Manuals Documentation
 
-OXI ONE MKII Manualプロジェクトの開発ドキュメントへようこそ。
+マニュアルビューアープロジェクトの開発ドキュメントへようこそ。
 
 ## ドキュメントカテゴリ
 
@@ -17,7 +17,7 @@ OXI ONE MKII Manualプロジェクトの開発ドキュメントへようこそ�
 
 ## プロジェクト概要
 
-このプロジェクトは、OXI ONE MKIIハードウェアシンセサイザーのマニュアルビューアーです。272ページのマニュアルをバイリンガル形式（英語のPDFページ + 日本語翻訳）で提供します。
+このプロジェクトは、ハードウェアシンセサイザーのマニュアルビューアーです。複数のマニュアルをバイリンガル形式（英語のPDFページ + 日本語翻訳）で提供します。
 
 ## 技術スタック
 

--- a/doc/docusaurus.config.ts
+++ b/doc/docusaurus.config.ts
@@ -3,8 +3,8 @@ import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
-  title: 'OXI ONE MKII Manual Documentation',
-  tagline: 'Development documentation for OXI ONE MKII manual viewer',
+  title: 'Takazudo Modular: Manuals',
+  tagline: 'Development documentation for manual viewer',
   // favicon: 'img/favicon.ico', // TODO: Add favicon later
 
   // Set the production url of your site here
@@ -109,7 +109,7 @@ const config: Config = {
       { name: 'googlebot', content: 'noindex, nofollow' },
     ],
     navbar: {
-      title: 'OXI ONE MKII Manual Docs',
+      title: 'Takazudo Modular: Manuals Docs',
       items: [
         {
           type: 'docSidebar',
@@ -122,7 +122,7 @@ const config: Config = {
     },
     footer: {
       style: 'dark',
-      copyright: `Copyright © ${new Date().getFullYear()} OXI ONE MKII Manual Project. Documentation built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Takazudo Modular. Documentation built with Docusaurus.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/doc/src/css/custom.css
+++ b/doc/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Custom CSS for OXI ONE MKII Manual Documentation
+ * Custom CSS for Takazudo Modular: Manuals Documentation
  * Base color: oklch(55.5% 0.163 48.998) - vibrant orange
  */
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "description": "OXI ONE MKII Manual Viewer - Japanese translation with Next.js",
+  "description": "Takazudo Modular: Manuals - Hardware synthesizer manuals with Japanese translations",
   "author": "Takazudo",
   "keywords": [
     "manual",


### PR DESCRIPTION
🤖 Post by Claude Code

---

- 依存PR
    - https://github.com/Takazudo/manual-oxi-one-mk2/pull/47

## 概要

プロジェクト名を「OXI ONE MKII Manual」から「Takazudo Modular: Manuals」に変更（複数マニュアル対応のため）。また、Next.js 15のscroll-behavior警告を修正。

## 変更内容

### プロジェクト名変更
- `app/layout.tsx` - メタデータ更新
- `doc/docusaurus.config.ts` - タイトル、tagline、navbar、copyright
- `doc/docs/*.md` - 見出しと説明
- `doc/src/css/custom.css` - コメント
- `package.json` - description

### Next.js 15 scroll警告修正
- `<html>`要素に`data-scroll-behavior="smooth"`属性追加

**注意:** 個別マニュアルのタイトル（例: 「OXI ONE MKII Manual」）は実際の製品名のため変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)