### PR TITLE
feat: keyboard navigation between top page and first page

### DIFF
--- a/app/[manualId]/page.tsx
+++ b/app/[manualId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import ctl from '@netlify/classnames-template-literals';
 import { ArrowLink } from '@/components/arrow-link';
+import { TopPageKeyboardNavigation } from '@/components/top-page-keyboard-navigation';
 import { getPagePath, getManualAssetPath } from '@/lib/manual-config';
 import { isValidManual, getAvailableManuals, getManifest } from '@/lib/manual-registry';
 
@@ -95,29 +96,32 @@ export default async function ManualLandingPage({ params }: ManualLandingPagePro
   const manifest = getManifest(manualId);
 
   return (
-    <main className={pageStyles}>
-      <div className="lg:-mx-hgap-2xl">
-        <h1 className={headingStyles}>
-          <span className={brandStyles}>{manifest.brand}:</span>
-          <span className={titleStyles}>{manifest.title}</span>
-          <span className={subtitleStyles}>Japanese Translation（日本語訳）</span>
-        </h1>
+    <>
+      <TopPageKeyboardNavigation manualId={manualId} />
+      <main className={pageStyles}>
+        <div className="lg:-mx-hgap-2xl">
+          <h1 className={headingStyles}>
+            <span className={brandStyles}>{manifest.brand}:</span>
+            <span className={titleStyles}>{manifest.title}</span>
+            <span className={subtitleStyles}>Japanese Translation（日本語訳）</span>
+          </h1>
 
-        <nav className={navStyles}>
-          <ArrowLink href={getPagePath(manualId, 1)}>日本語訳付きマニュアルを読む</ArrowLink>
-          <ArrowLink href={getManualAssetPath(manualId, 'original.pdf')} external>
-            英語版オリジナル（PDF）
-          </ArrowLink>
-        </nav>
+          <nav className={navStyles}>
+            <ArrowLink href={getPagePath(manualId, 1)}>日本語訳付きマニュアルを読む</ArrowLink>
+            <ArrowLink href={getManualAssetPath(manualId, 'original.pdf')} external>
+              英語版オリジナル（PDF）
+            </ArrowLink>
+          </nav>
 
-        <p className={footerStyles}>
-          <span>
-            Navigation: <code className={codeStyles}>←</code> <code className={codeStyles}>→</code>{' '}
-            key
-          </span>
-          {manifest.updatedAt && <span>Updated: {formatUpdatedAt(manifest.updatedAt)}</span>}
-        </p>
-      </div>
-    </main>
+          <p className={footerStyles}>
+            <span>
+              Navigation: <code className={codeStyles}>←</code>{' '}
+              <code className={codeStyles}>→</code> key
+            </span>
+            {manifest.updatedAt && <span>Updated: {formatUpdatedAt(manifest.updatedAt)}</span>}
+          </p>
+        </div>
+      </main>
+    </>
   );
 }

--- a/components/keyboard-navigation.tsx
+++ b/components/keyboard-navigation.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { getNavigationState } from '@/lib/manual-data';
-import { getPagePath } from '@/lib/manual-config';
+import { getPagePath, getManualBasePath } from '@/lib/manual-config';
 
 interface KeyboardNavigationProps {
   currentPage: number;
@@ -13,7 +13,7 @@ interface KeyboardNavigationProps {
 
 /**
  * Keyboard navigation for manual pages
- * - Left arrow: Previous page
+ * - Left arrow: Previous page (or top page if on page 1)
  * - Right arrow: Next page
  */
 export function KeyboardNavigation({ currentPage, totalPages, manualId }: KeyboardNavigationProps) {
@@ -47,11 +47,14 @@ export function KeyboardNavigation({ currentPage, totalPages, manualId }: Keyboa
       const { currentPage, totalPages, manualId } = stateRef.current;
       const { canGoToPrev, canGoToNext } = getNavigationState(currentPage, totalPages);
 
-      // Left arrow: Previous page
+      // Left arrow: Previous page (or top page if on page 1)
       if (e.key === 'ArrowLeft') {
         e.preventDefault();
         if (canGoToPrev) {
           routerRef.current.push(getPagePath(manualId, currentPage - 1));
+        } else if (currentPage === 1) {
+          // On first page, go back to manual top page
+          routerRef.current.push(getManualBasePath(manualId));
         }
       }
       // Right arrow: Next page

--- a/components/keyboard-navigation.tsx
+++ b/components/keyboard-navigation.tsx
@@ -34,7 +34,10 @@ export function KeyboardNavigation({ currentPage, totalPages, manualId }: Keyboa
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Ignore if user is typing in an input/textarea/select or contentEditable element
-      const target = e.target as HTMLElement;
+      const target = e.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
       if (
         target.tagName === 'INPUT' ||
         target.tagName === 'TEXTAREA' ||

--- a/components/top-page-keyboard-navigation.tsx
+++ b/components/top-page-keyboard-navigation.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { getPagePath } from '@/lib/manual-config';
+
+interface TopPageKeyboardNavigationProps {
+  manualId: string;
+}
+
+/**
+ * Keyboard navigation for manual top page
+ * - Right arrow: Go to first page
+ */
+export function TopPageKeyboardNavigation({ manualId }: TopPageKeyboardNavigationProps) {
+  const router = useRouter();
+  const routerRef = useRef(router);
+  const manualIdRef = useRef(manualId);
+
+  // Keep refs up to date
+  useEffect(() => {
+    routerRef.current = router;
+  }, [router]);
+
+  useEffect(() => {
+    manualIdRef.current = manualId;
+  }, [manualId]);
+
+  // Set up keyboard listener only once
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Ignore if user is typing in an input/textarea/select or contentEditable element
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      // Right arrow: Go to first page
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        routerRef.current.push(getPagePath(manualIdRef.current, 1));
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []); // Empty dependency array - listener set up only once
+
+  return null; // This component doesn't render anything
+}

--- a/components/top-page-keyboard-navigation.tsx
+++ b/components/top-page-keyboard-navigation.tsx
@@ -30,7 +30,10 @@ export function TopPageKeyboardNavigation({ manualId }: TopPageKeyboardNavigatio
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Ignore if user is typing in an input/textarea/select or contentEditable element
-      const target = e.target as HTMLElement;
+      const target = e.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
       if (
         target.tagName === 'INPUT' ||
         target.tagName === 'TEXTAREA' ||


### PR DESCRIPTION
## Summary
- Add right arrow navigation from PDF top page to first detail page
- Add left arrow navigation from first detail page back to PDF top page
- Enables smooth keyboard-only navigation through the entire manual

## Changes
- `components/keyboard-navigation.tsx`: Modified to navigate to top page when on page 1 and left arrow is pressed
- `components/top-page-keyboard-navigation.tsx`: New component for top page keyboard navigation
- `app/[manualId]/page.tsx`: Added keyboard navigation to the PDF landing page

## Test plan
- [ ] Navigate to a manual top page (e.g., `/manuals/addac511-svgen`)
- [ ] Press right arrow → should go to page 1
- [ ] On page 1, press left arrow → should go back to top page
- [ ] On page 2+, left/right navigation works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)