### PR TITLE
feat: add productSlug field to manifests for product linking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 NETLIFY_AUTH_TOKEN=xxxxxx
 NETLIFY_SITE_ID=xxxxxx
+
+# Path to takazudomodular repo for product data lookup during pdf-process
+TAKAZUDO_MODULAR_REPO_PATH=/Users/takazudo/repos/personal/takazudomodular

--- a/public/addac104-tnetw/data/manifest.json
+++ b/public/addac104-tnetw/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC104 VC T-Networks: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac104",
   "updatedAt": "20260112",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/addac106-tnoise/data/manifest.json
+++ b/public/addac106-tnoise/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC106 T-Noiseworks: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac106",
   "updatedAt": "20260112",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/addac107-acids/data/manifest.json
+++ b/public/addac107-acids/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC107 Acid Source: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac107",
   "updatedAt": "20260112",
   "version": "1.0.0",
   "totalPages": 7,

--- a/public/addac112-looper/data/manifest.json
+++ b/public/addac112-looper/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC112 VC Looper: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac112",
   "updatedAt": "20260112",
   "version": "1.0.0",
   "totalPages": 45,

--- a/public/addac200pi-pedal-diy/data/manifest.json
+++ b/public/addac200pi-pedal-diy/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC200PI Pedal Interface: DIY Guide",
   "brand": "ADDAC System",
+  "productSlug": "addac200pi",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 10,

--- a/public/addac207-quantizer/data/manifest.json
+++ b/public/addac207-quantizer/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC207 Quantizer: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac207",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 36,

--- a/public/addac210-open-heart/data/manifest.json
+++ b/public/addac210-open-heart/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC210 Open Heart Surgery: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac210",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 14,

--- a/public/addac215-sh/data/manifest.json
+++ b/public/addac215-sh/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC215 Sample & Hold: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac215",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 7,

--- a/public/addac216-sumdiff/data/manifest.json
+++ b/public/addac216-sumdiff/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC216 Sum & Difference: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac216",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/addac217-gate2trig/data/manifest.json
+++ b/public/addac217-gate2trig/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC217 Gate to Trigger: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac217",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/addac218-atten/data/manifest.json
+++ b/public/addac218-atten/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC218 Attenuator: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac218",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/addac219in-stereo-diy/data/manifest.json
+++ b/public/addac219in-stereo-diy/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC219IN Stereo > Dual Mono: DIY Guide",
   "brand": "ADDAC System",
+  "productSlug": "addac219in",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 7,

--- a/public/addac219out-stereo-diy/data/manifest.json
+++ b/public/addac219out-stereo-diy/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC219OUT Dual Mono > Stereo: DIY Guide",
   "brand": "ADDAC System",
+  "productSlug": "addac219out",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/addac304-manualgates-diy/data/manifest.json
+++ b/public/addac304-manualgates-diy/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC304 Manual Gates: DIY Guide",
   "brand": "ADDAC System",
+  "productSlug": "addac304",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 12,

--- a/public/addac305-latches-diy/data/manifest.json
+++ b/public/addac305-latches-diy/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC305 Manual Latches: DIY Guide",
   "brand": "ADDAC System",
+  "productSlug": "addac305",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 12,

--- a/public/addac511-svgen/data/manifest.json
+++ b/public/addac511-svgen/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC511 VC Stochastic Voltage Generator: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac511",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 65,

--- a/public/addac604-filter/data/manifest.json
+++ b/public/addac604-filter/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC604 Dual Filter: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac604",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/addac712-vintpre/data/manifest.json
+++ b/public/addac712-vintpre/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC712 Vintage Pre: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac712",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/addac713-stereomix/data/manifest.json
+++ b/public/addac713-stereomix/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC713 Stereo Discrete Mixer: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac713",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/addac714-vintclip/data/manifest.json
+++ b/public/addac714-vintclip/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "ADDAC714 Vintage Clipper: Manual",
   "brand": "ADDAC System",
+  "productSlug": "addac714",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 5,

--- a/public/oxi-coral/data/manifest.json
+++ b/public/oxi-coral/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "OXI Coral: Manual",
   "brand": "OXI Instruments",
+  "productSlug": "oxi-coral",
   "version": "1.0.0",
   "totalPages": 46,
   "contentPages": 46,

--- a/public/oxi-e16-manual/data/manifest.json
+++ b/public/oxi-e16-manual/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "OXI E16 Manual",
   "brand": "OXI Instruments",
+  "productSlug": "oxi-e16",
   "version": "1.0.0",
   "totalPages": 74,
   "contentPages": 68,

--- a/public/oxi-e16-quick-start/data/manifest.json
+++ b/public/oxi-e16-quick-start/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "OXI E16: Quick Start",
   "brand": "OXI Instruments",
+  "productSlug": "oxi-e16",
   "version": "1.0.0",
   "totalPages": 4,
   "contentPages": 4,

--- a/public/oxi-one-mk2/data/manifest.json
+++ b/public/oxi-one-mk2/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "OXI ONE MKII: Manual",
   "brand": "OXI Instruments",
+  "productSlug": "oxi-one-mk2-black",
   "version": "1.0.0",
   "totalPages": 272,
   "contentPages": 260,

--- a/public/weston-2v2/data/manifest.json
+++ b/public/weston-2v2/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "2V2 Dual Analog Oscillator: Manual",
   "brand": "Weston Precision Audio",
+  "productSlug": "2v2",
   "updatedAt": "20260114",
   "version": "1.0.0",
   "totalPages": 8,

--- a/public/weston-h1/data/manifest.json
+++ b/public/weston-h1/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "H1 Analog Harmonizer: Manual",
   "brand": "Weston Precision Audio",
+  "productSlug": "h1",
   "updatedAt": "20260114",
   "version": "1.0.0",
   "totalPages": 20,

--- a/public/weston-hv1/data/manifest.json
+++ b/public/weston-hv1/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "HV1 Hybrid Oscillator: Manual",
   "brand": "Weston Precision Audio",
+  "productSlug": "hv1",
   "updatedAt": "20260113",
   "version": "1.0.0",
   "totalPages": 20,

--- a/public/weston-pa0/data/manifest.json
+++ b/public/weston-pa0/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "PA0 Phase Animated Oscillator: Manual",
   "brand": "Weston Precision Audio",
+  "productSlug": "pa0",
   "updatedAt": "20260114",
   "version": "1.0.0",
   "totalPages": 11,

--- a/public/weston-se1/data/manifest.json
+++ b/public/weston-se1/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "SE1 Shaped VC Envelope: Manual",
   "brand": "Weston Precision Audio",
+  "productSlug": "se1",
   "updatedAt": "20260114",
   "version": "1.0.0",
   "totalPages": 10,

--- a/public/weston-sf1/data/manifest.json
+++ b/public/weston-sf1/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "SF1 Stereo / Dual Filter: Manual",
   "brand": "Weston Precision Audio",
+  "productSlug": "sf1",
   "updatedAt": "20260114",
   "version": "1.0.0",
   "totalPages": 12,

--- a/public/weston-sv1/data/manifest.json
+++ b/public/weston-sv1/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "SV1 Dual / Stereo VCA: Manual",
   "brand": "Weston Precision Audio",
+  "productSlug": "sv1",
   "updatedAt": "20260114",
   "version": "1.0.0",
   "totalPages": 10,

--- a/public/weston-tz0/data/manifest.json
+++ b/public/weston-tz0/data/manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "TZ0 Thru-Zero Oscillator: Manual",
   "brand": "Weston Precision Audio",
+  "productSlug": "tz0",
   "updatedAt": "20260114",
   "version": "1.0.0",
   "totalPages": 7,


### PR DESCRIPTION
## Summary
- Add `productSlug` field to all manual manifests for linking to takazudomodular products
- Enhance pdf-process skill with auto-detection of product slug from takazudomodular repo
- Add `TAKAZUDO_MODULAR_REPO_PATH` environment variable for product data lookup

## Test plan
- [ ] Verify manifest.json files have productSlug field
- [ ] Test pdf-process skill with new productSlug auto-detection
- [ ] Build succeeds with updated manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)