### PR TITLE
doc: deploy, tweak, and upgrade Docusaurus features

### DIFF
--- a/doc/docusaurus.config.ts
+++ b/doc/docusaurus.config.ts
@@ -8,14 +8,17 @@ const config: Config = {
   // favicon: 'img/favicon.ico', // TODO: Add favicon later
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-site.example.com',
+  url: 'https://manual-oxi-one-mk2.netlify.app',
   // Set the /<baseUrl>/ pathname under which your site is served
-  baseUrl: '/doc/',
+  // Must include /manuals/ prefix because the whole site is served under basePath /manuals/
+  baseUrl: '/manuals/doc/',
 
   // Don't add trailing slash
   trailingSlash: false,
 
   onBrokenLinks: 'throw',
+  onBrokenAnchors: 'warn',
+  onDuplicateRoutes: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang.
@@ -34,6 +37,32 @@ const config: Config = {
     },
   },
   themes: ['@docusaurus/theme-mermaid'],
+
+  // Load Noto Sans JP font from Google Fonts
+  headTags: [
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preconnect',
+        href: 'https://fonts.googleapis.com',
+      },
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preconnect',
+        href: 'https://fonts.gstatic.com',
+        crossorigin: 'anonymous',
+      },
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'stylesheet',
+        href: 'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap',
+      },
+    },
+  ],
 
   presets: [
     [
@@ -122,7 +151,7 @@ const config: Config = {
           type: 'html',
           position: 'right',
           value:
-            '<a href="https://takazudomodular.com/" class="navbar__takazudo-modular" rel="noopener noreferrer"><img src="/doc/img/logo.svg" alt="" /><span>Takazudo Modular</span></a>',
+            '<a href="https://takazudomodular.com/" class="navbar__takazudo-modular" rel="noopener noreferrer"><img src="/manuals/doc/img/logo.svg" alt="" /><span>Takazudo Modular</span></a>',
         },
       ],
     },

--- a/doc/package.json
+++ b/doc/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "generate-category-nav": "node scripts/generate-category-nav.js",
+    "generate-doc-titles": "node scripts/generate-doc-titles.js",
     "start": "docusaurus start --port 3100 --host doc-zmanuals.localhost",
-    "build": "npm run generate-category-nav && docusaurus build",
+    "build": "npm run generate-category-nav && npm run generate-doc-titles && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/doc/scripts/generate-doc-titles.js
+++ b/doc/scripts/generate-doc-titles.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Generate doc-titles.json mapping doc IDs to display titles.
+ * Reads all markdown files in docs/ and extracts titles from
+ * frontmatter or first h1 heading.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const DOCS_DIR = path.join(__dirname, '../docs');
+const OUTPUT_FILE = path.join(__dirname, '../src/data/doc-titles.json');
+
+/**
+ * Recursively find all .md and .mdx files
+ */
+function findMarkdownFiles(dirPath) {
+  const results = [];
+
+  if (!fs.existsSync(dirPath)) {
+    return results;
+  }
+
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findMarkdownFiles(fullPath));
+    } else if (entry.isFile() && (entry.name.endsWith('.md') || entry.name.endsWith('.mdx'))) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Extract title from a markdown file (frontmatter > h1 > filename)
+ */
+function extractTitle(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  // Try frontmatter first
+  try {
+    const { data } = matter(content);
+    if (data.title) {
+      return data.title;
+    }
+  } catch (e) {
+    // Ignore frontmatter parse errors
+  }
+
+  // Fall back to first H1 heading
+  const h1Match = content.match(/^#\s+(.+)$/m);
+  if (h1Match) {
+    return h1Match[1].trim();
+  }
+
+  // Fall back to filename
+  const basename = path.basename(filePath, path.extname(filePath));
+  if (basename === 'index') {
+    return path.basename(path.dirname(filePath));
+  }
+  return basename;
+}
+
+/**
+ * Get doc ID from file path (relative to docs dir, without extension)
+ */
+function getDocId(filePath) {
+  const relativePath = path.relative(DOCS_DIR, filePath);
+  return relativePath.replace(/\.(md|mdx)$/, '').replace(/\\/g, '/');
+}
+
+function main() {
+  console.log('Generating doc-titles.json...');
+
+  const files = findMarkdownFiles(DOCS_DIR);
+  const docTitles = {};
+
+  for (const file of files) {
+    const docId = getDocId(file);
+    const title = extractTitle(file);
+    docTitles[docId] = title;
+  }
+
+  // Sort by key for consistent output
+  const sorted = {};
+  for (const key of Object.keys(docTitles).sort()) {
+    sorted[key] = docTitles[key];
+  }
+
+  // Ensure output directory exists
+  const outputDir = path.dirname(OUTPUT_FILE);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(sorted, null, 2) + '\n');
+
+  console.log(`  Generated ${Object.keys(sorted).length} entries`);
+  console.log(`  Output: ${OUTPUT_FILE}`);
+}
+
+main();

--- a/doc/src/css/custom.css
+++ b/doc/src/css/custom.css
@@ -1,22 +1,25 @@
 /**
  * Custom CSS for Takazudo Modular: Manuals Documentation
- * Base color: oklch(55.5% 0.163 48.998) - vibrant orange
+ * Base color: oklch(44.8% 0.119 151.328) - green
  */
 
-/* Light mode color palette based on oklch(55.5% 0.163 48.998) */
+/* Light mode color palette based on oklch(44.8% 0.119 151.328) */
 :root {
-  --ifm-color-primary: oklch(55.5% 0.163 48.998);
-  --ifm-color-primary-dark: oklch(50% 0.163 48.998);
-  --ifm-color-primary-darker: oklch(47% 0.163 48.998);
-  --ifm-color-primary-darkest: oklch(40% 0.163 48.998);
-  --ifm-color-primary-light: oklch(60% 0.163 48.998);
-  --ifm-color-primary-lighter: oklch(63% 0.163 48.998);
-  --ifm-color-primary-lightest: oklch(70% 0.163 48.998);
+  --ifm-color-primary: oklch(44.8% 0.119 151.328);
+  --ifm-color-primary-dark: oklch(40% 0.119 151.328);
+  --ifm-color-primary-darker: oklch(37% 0.119 151.328);
+  --ifm-color-primary-darkest: oklch(30% 0.119 151.328);
+  --ifm-color-primary-light: oklch(50% 0.119 151.328);
+  --ifm-color-primary-lighter: oklch(53% 0.119 151.328);
+  --ifm-color-primary-lightest: oklch(60% 0.119 151.328);
 
   /* Additional settings */
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-container-width-xl: 1800px;
+
+  /* Noto Sans JP for Japanese text */
+  --ifm-font-family-base: 'Noto Sans JP', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 
   /* Japanese-optimized typography */
   --ifm-line-height-base: 1.7;
@@ -25,13 +28,13 @@
 
 /* Dark mode color palette - brighter and less saturated for readability */
 [data-theme='dark'] {
-  --ifm-color-primary: oklch(65% 0.14 48.998);
-  --ifm-color-primary-dark: oklch(60% 0.14 48.998);
-  --ifm-color-primary-darker: oklch(57% 0.14 48.998);
-  --ifm-color-primary-darkest: oklch(50% 0.14 48.998);
-  --ifm-color-primary-light: oklch(70% 0.14 48.998);
-  --ifm-color-primary-lighter: oklch(73% 0.14 48.998);
-  --ifm-color-primary-lightest: oklch(80% 0.14 48.998);
+  --ifm-color-primary: oklch(65% 0.1 151.328);
+  --ifm-color-primary-dark: oklch(60% 0.1 151.328);
+  --ifm-color-primary-darker: oklch(57% 0.1 151.328);
+  --ifm-color-primary-darkest: oklch(50% 0.1 151.328);
+  --ifm-color-primary-light: oklch(70% 0.1 151.328);
+  --ifm-color-primary-lighter: oklch(73% 0.1 151.328);
+  --ifm-color-primary-lightest: oklch(80% 0.1 151.328);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
@@ -161,22 +164,22 @@ article.theme-doc-markdown {
 }
 
 .markdown th {
-  background-color: oklch(55.5% 0.163 48.998 / 0.1);
+  background-color: oklch(44.8% 0.119 151.328 / 0.1);
 }
 
 [data-theme='dark'] .markdown th {
-  background-color: oklch(65% 0.14 48.998 / 0.2);
+  background-color: oklch(65% 0.1 151.328 / 0.2);
 }
 
 /* Blockquote styling */
 .markdown blockquote {
-  border-left-color: oklch(55.5% 0.163 48.998);
-  background-color: oklch(55.5% 0.163 48.998 / 0.05);
+  border-left-color: oklch(44.8% 0.119 151.328);
+  background-color: oklch(44.8% 0.119 151.328 / 0.05);
 }
 
 [data-theme='dark'] .markdown blockquote {
-  border-left-color: oklch(65% 0.14 48.998);
-  background-color: oklch(65% 0.14 48.998 / 0.1);
+  border-left-color: oklch(65% 0.1 151.328);
+  background-color: oklch(65% 0.1 151.328 / 0.1);
 }
 
 /* Responsive breakpoints */
@@ -228,20 +231,20 @@ article.theme-doc-markdown {
 
 /* Search plugin styling */
 .navbar__search-input {
-  background-color: oklch(55.5% 0.163 48.998 / 0.1);
+  background-color: oklch(44.8% 0.119 151.328 / 0.1);
 }
 
 [data-theme='dark'] .navbar__search-input {
-  background-color: oklch(65% 0.14 48.998 / 0.15);
+  background-color: oklch(65% 0.1 151.328 / 0.15);
 }
 
 /* Navbar brand color */
 .navbar__brand {
-  color: oklch(55.5% 0.163 48.998);
+  color: oklch(44.8% 0.119 151.328);
 }
 
 [data-theme='dark'] .navbar__brand {
-  color: oklch(65% 0.14 48.998);
+  color: oklch(65% 0.1 151.328);
 }
 
 /* Takazudo Modular right-side nav link */
@@ -270,11 +273,11 @@ article.theme-doc-markdown {
 
 /* Footer styling */
 .footer {
-  background-color: oklch(30% 0.163 48.998);
+  background-color: oklch(30% 0.119 151.328);
 }
 
 [data-theme='dark'] .footer {
-  background-color: oklch(20% 0.14 48.998);
+  background-color: oklch(20% 0.1 151.328);
 }
 
 /* Document dates container (created + updated) */

--- a/doc/src/data/doc-titles.json
+++ b/doc/src/data/doc-titles.json
@@ -1,5 +1,5 @@
 {
-  "inbox/index": "INBOX",
   "inbox/design-system": "Design System",
+  "inbox/index": "INBOX",
   "inbox/pdf-to-nextjs-architecture": "PDF Processing to Next.js Architecture"
 }

--- a/doc/src/pages/index.module.css
+++ b/doc/src/pages/index.module.css
@@ -61,37 +61,6 @@
   filter: brightness(0) invert(1);
 }
 
-/* Stats Section */
-.statsSection h2 {
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
-}
-
-.statsGrid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-}
-
-.statItem {
-  text-align: center;
-  padding: 1.5rem;
-  background: var(--ifm-color-emphasis-100);
-  border-radius: 8px;
-}
-
-.statNumber {
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: var(--ifm-color-primary);
-  margin-bottom: 0.5rem;
-}
-
-.statLabel {
-  font-size: 1rem;
-  color: var(--ifm-color-emphasis-700);
-}
-
 /* Links Section */
 .linksSection h2 {
   font-size: 1.5rem;

--- a/doc/src/pages/index.tsx
+++ b/doc/src/pages/index.tsx
@@ -46,29 +46,6 @@ export default function Home(): ReactNode {
                   </li>
                 </ul>
               </section>
-
-              {/* Tech Stack Section */}
-              <section className={styles.statsSection}>
-                <h2>Tech Stack</h2>
-                <div className={styles.statsGrid}>
-                  <div className={styles.statItem}>
-                    <div className={styles.statNumber}>Next.js</div>
-                    <div className={styles.statLabel}>Framework</div>
-                  </div>
-                  <div className={styles.statItem}>
-                    <div className={styles.statNumber}>React 19</div>
-                    <div className={styles.statLabel}>UI Library</div>
-                  </div>
-                  <div className={styles.statItem}>
-                    <div className={styles.statNumber}>TypeScript</div>
-                    <div className={styles.statLabel}>Language</div>
-                  </div>
-                  <div className={styles.statItem}>
-                    <div className={styles.statNumber}>Tailwind v4</div>
-                    <div className={styles.statLabel}>Styling</div>
-                  </div>
-                </div>
-              </section>
             </div>
           </aside>
 

--- a/doc/src/theme/MDXContent/index.tsx
+++ b/doc/src/theme/MDXContent/index.tsx
@@ -1,0 +1,86 @@
+import React, { type ReactNode, Component } from 'react';
+import OriginalMDXContent from '@theme-original/MDXContent';
+import type MDXContentType from '@theme/MDXContent';
+import type { WrapperProps } from '@docusaurus/types';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+
+type Props = WrapperProps<typeof MDXContentType>;
+
+/**
+ * Error boundary to safely render DocMetaInner.
+ * useDoc() throws when not in a doc context (e.g., standalone pages).
+ * This boundary catches that error and renders nothing.
+ */
+class MetaErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}
+
+function formatTimestamp(timestamp: number): string {
+  const d = new Date(timestamp * 1000);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}/${m}/${day}`;
+}
+
+/**
+ * Renders creation date, last updated, and author metadata under h1.
+ * Positioned via CSS flexbox ordering in custom.css (.theme-doc-meta).
+ */
+function DocMetaInner(): ReactNode {
+  const { metadata, frontMatter } = useDoc();
+
+  const creationDate = frontMatter.custom_creation_date as string | undefined;
+  const lastUpdatedAt = metadata.lastUpdatedAt;
+  const lastUpdatedBy = metadata.lastUpdatedBy;
+
+  if (!creationDate && !lastUpdatedAt) {
+    return null;
+  }
+
+  return (
+    <div className="theme-doc-meta">
+      {creationDate && (
+        <div className="theme-doc-meta-created">
+          <span>Created:</span> {creationDate}
+        </div>
+      )}
+      {lastUpdatedAt && (
+        <div className="theme-doc-meta-updated">
+          <span>Updated:</span> {formatTimestamp(lastUpdatedAt)}
+        </div>
+      )}
+      {lastUpdatedBy && (
+        <div className="theme-doc-meta-author">
+          <span>Author:</span> <address>{lastUpdatedBy}</address>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Swizzled MDXContent wrapper that injects document metadata.
+ * The metadata element is rendered as a sibling inside .markdown,
+ * positioned after h1 via CSS order: -1.
+ */
+export default function MDXContentWrapper(props: Props): ReactNode {
+  return (
+    <>
+      <MetaErrorBoundary>
+        <DocMetaInner />
+      </MetaErrorBoundary>
+      <OriginalMDXContent {...props} />
+    </>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "dev": "pnpm run _kill-port && next dev -p 3100 --hostname zmanuals.localhost",
     "_kill-port": "lsof -ti:3100 | xargs kill -9 2>/dev/null || true; echo 'Killed processes on port 3100 (if any)'",
-    "build": "next build && node scripts/copy-original-pdfs.js && node scripts/restructure-build.js",
+    "build": "next build && node scripts/copy-original-pdfs.js && node scripts/restructure-build.js && pnpm run doc:build && cp -r doc/build/* out/manuals/doc/",
     "start": "next start",
     "serve": "pnpm dlx serve out -l 3100",
     "doc:dev": "cd doc && pnpm run start",


### PR DESCRIPTION
## Summary

- **Deploy doc with main app**: Updated Docusaurus baseUrl to `/manuals/doc/`, integrated doc build into the main `pnpm build` script so the doc site is deployed alongside the Next.js app at `/manuals/doc/`
- **UI tweaks**: Removed Tech Stack section from landing page, changed theme color palette from orange to green (oklch hue 151.328)
- **Docusaurus feature upgrades**: Added Noto Sans JP font, h1 metadata display (creation date/updated/author), doc-titles.json generation script, config improvements (onBrokenAnchors, onDuplicateRoutes)

## Changes

### Part 1: Deploy doc with main app
- `docusaurus.config.ts`: Set `url` to production URL, `baseUrl` to `/manuals/doc/`
- `package.json` (root): Updated build script to include `pnpm run doc:build && cp -r doc/build/* out/manuals/doc/`
- Fixed hardcoded navbar logo path for new baseUrl

### Part 2: Doc tweaks
- Removed "Tech Stack" section from `index.tsx` and cleaned up unused CSS
- Changed all oklch color values from hue `48.998` (orange) to `151.328` (green)

### Part 3: Docusaurus feature upgrades
- Added Noto Sans JP font via Google Fonts `headTags`
- Created swizzled `MDXContent` component to render doc metadata (creation date, last updated, author) under h1
- Created `generate-doc-titles.js` script for automated doc-titles.json generation
- Added `onBrokenAnchors: 'warn'` and `onDuplicateRoutes: 'warn'` config

## Test plan

- [x] `cd doc && pnpm run build` succeeds
- [ ] Verify doc site is accessible at `/manuals/doc/` after full build
- [ ] Verify green color theme renders correctly
- [ ] Verify Noto Sans JP font loads
- [ ] Verify h1 metadata (creation date, updated) displays on doc pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)