### PR TITLE
claudemd: refactor CLAUDE.md into focused files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,174 @@
+# Claude Code Configuration - CLAUDE.md
+
+Claude Code-specific workflow details. For project-wide instructions, see the root `CLAUDE.md`.
+
+## Git Worktree Workflow (Detailed)
+
+We use git worktrees under `worktrees/{tree-name}/` for topic-based development.
+
+### CRITICAL: Always Check Your Current Directory Before Git Operations
+
+**MANDATORY CHECK BEFORE ANY GIT OPERATION:**
+
+```bash
+# ALWAYS run this before ANY git operation (commit, push, checkout, branch, etc.)
+pwd
+```
+
+**If the output contains `/worktrees/`:**
+
+- STOP - You are in a git worktree
+- Any git operation will affect the WORKTREE BRANCH, not main
+- Navigate back to repo root first if you need to work on main
+
+### Two Different Session Contexts
+
+#### Context 1: Root Session (Manager Role)
+
+**Started from:** Repository root
+**Purpose:** Manage project, review work, merge PRs
+**Git operations:** Affect `main` branch
+**RULE:** Never cd into `/worktrees/{slug}/` and do git operations
+
+#### Context 2: Worktree Session (Worker Role)
+
+**Started from:** `worktrees/{slug}/`
+**Purpose:** Work on specific issue/task
+**Git operations:** Affect the worktree's feature branch
+**RULE:** All work happens here, commits go to feature branch
+
+### NEVER Mix Contexts
+
+**If you started in ROOT (manager session):**
+
+- NEVER cd into `/worktrees/{slug}/` and do git operations
+- DO read files from worktrees for reference
+- DO review PRs, merge branches, manage the project
+
+**If you started in WORKTREE (worker session):**
+
+- All your work happens here
+- Commits and pushes go to the feature branch
+- When done, create PR to merge into main
+
+### Common Mistake Example
+
+```bash
+# WRONG - This is a disaster waiting to happen:
+# (Started session in repo root)
+pwd                           # /Users/.../manual-oxi-one-mk2
+cd worktrees/issue-3-docusaurus/
+git add .
+git commit -m "fix"          # Commits to issue-3 branch, NOT main!
+git push                     # Pushes to wrong branch!
+
+# CORRECT - Always check where you are:
+pwd                           # /Users/.../manual-oxi-one-mk2
+# If you need to work on issue-3, start a NEW session in that worktree
+# Don't cd there from root session!
+```
+
+### How to Detect You're in a Worktree
+
+```bash
+# Method 1: Check current path
+pwd
+# If output contains '/worktrees/', you're in a worktree
+
+# Method 2: Check git branch
+git branch --show-current
+# If it shows 'issue-X--something', you're likely in a worktree
+
+# Method 3: Check worktree list
+git worktree list
+# Shows all active worktrees and their branches
+```
+
+### Before Any Git Command: Checklist
+
+Before running `git add`, `git commit`, `git push`, `git checkout`, `git branch`, or `git merge`:
+
+1. Run `pwd` to confirm your location
+2. Ask: "Am I in the right context for this operation?"
+3. Ask: "Will this affect the correct branch?"
+
+### Always Pull Before Creating Worktree
+
+**MANDATORY**: Pull the latest base branch before creating a worktree to ensure it includes all merged changes.
+
+```bash
+# CORRECT - Pull first, then create worktree
+git checkout main
+git pull origin main
+pnpm run init-worktree issue-3-docusaurus
+
+# WRONG - Creating worktree from stale local branch
+pnpm run init-worktree issue-3-docusaurus  # Missing merged PRs!
+```
+
+**Why this matters:**
+
+- Worktrees created from stale branches are missing merged PRs
+- Implementation sessions fail due to missing dependencies
+- Wasted time reimplementing code that already exists
+
+**Always follow this sequence:**
+
+1. Merge any pending PRs
+2. Pull latest base branch
+3. Create worktree
+4. Verify worktree has expected files
+
+### init-worktree Command
+
+```bash
+pnpm run init-worktree <worktree-name>
+```
+
+**What it does:**
+
+1. Creates `worktrees/<worktree-name>` using `git worktree add` (if it doesn't exist)
+2. Sets up symbolic links for environment files from the repo root
+3. Ensures environment settings are shared across worktrees
+
+**Example:**
+
+```bash
+# Create and initialize a worktree for a new feature
+pnpm run init-worktree issue-2-project-setup
+
+# This creates worktrees/issue-2-project-setup/ with all environment files linked
+```
+
+## Claude Code Skills & Agents
+
+### Skills
+
+- **`/l-pdf-process`** - Run the complete PDF processing pipeline (see `scripts/CLAUDE.md`)
+- **`/l-verify-translation`** - Capture and verify translations against page images
+- **`capture-all-pages`** - Capture screenshots of all manual pages at high resolution
+- **`/l-b4push`** - Run pre-push checks
+
+### Agents
+
+- **`manual-translator`** (`.claude/agents/manual-translator.md`) - Translates PDF manual pages from English to Japanese
+
+### Skills Directory Structure
+
+```
+.claude/
+├── CLAUDE.md               # This file
+├── agents/
+│   └── manual-translator.md    # Translation agent prompt
+├── commands/
+│   └── l-b4push.md            # Pre-push check command
+└── skills/
+    ├── capture-all-pages/      # Page screenshot capture
+    │   ├── SKILL.md
+    │   └── scripts/capture.js
+    ├── pdf-process/            # PDF processing pipeline
+    │   └── SKILL.md
+    └── verify-translation/     # Translation verification
+        ├── SKILL.md
+        └── scripts/capture-pages.js
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,894 +16,109 @@ This is a Next.js-based manual viewer for the OXI ONE MKII hardware synthesizer 
 
 **Deployed Website**: https://manual-oxi-one-mk2.netlify.app/
 
-- This is the live production website that corresponds to the content in this repository
 - Full URL: `https://manual-oxi-one-mk2.netlify.app/manuals/oxi-one-mk2/`
-- When referencing URLs like https://manual-oxi-one-mk2.netlify.app/manuals/oxi-one-mk2/*, the content exists in this repository
 - The deployed site reflects the current state of the main branch
 - Preview URLs: `https://*--manual-oxi-one-mk2.netlify.app/manuals/oxi-one-mk2/`
-- We use preview URLs for previewing PRs before merging to main
 
 ## basePath Configuration (Critical Architecture Decision)
 
 **This site uses `basePath: '/manuals'` in `next.config.js`.**
 
-### Why basePath is Required
+This site is proxied through `takazudomodular.com/manuals/*` via a Netlify redirect. Without basePath, CSS/JS assets would 404.
 
-This site is proxied through `takazudomodular.com/manuals/*` via a Netlify redirect:
+**Key rules:**
 
-```
-# From takazudomodular.com/_redirects
-/manuals/*  https://manual-oxi-one-mk2.netlify.app/manuals/:splat  200
-```
-
-This means:
-
-- All requests to `takazudomodular.com/manuals/*` are proxied to this site
-- **Only paths under `/manuals/` are proxied** - paths like `/_next/static/*` are NOT proxied
-- Without basePath, CSS/JS assets at `/_next/static/*` would return 404
-
-### Impact on Development
-
-**Route paths (for `<Link>`, `router.push()`):**
-
-- Don't include `/manuals` prefix - basePath adds it automatically
-- Example: `<Link href="/oxi-one-mk2/page/1">` → URL becomes `/manuals/oxi-one-mk2/page/1`
-
-**Static asset paths (for `<img>`, `<a href>` to files):**
-
-- Don't include `/manuals` prefix - basePath adds it automatically
-- Files are served from `/public/{manualId}/`
-- Example: `<img src="/oxi-one-mk2/pages/page-001.png">` → URL becomes `/manuals/oxi-one-mk2/pages/page-001.png`
-
-**App directory structure:**
-
-- Routes are defined WITHOUT the `/manuals` prefix
-- `/app/page.tsx` → served at `/manuals/`
-- `/app/[manualId]/page.tsx` → served at `/manuals/[manualId]`
-- `/app/[manualId]/page/[pageNum]/page.tsx` → served at `/manuals/[manualId]/page/[pageNum]`
-
-**usePathname() returns paths WITHOUT basePath:**
-
-- URL `/manuals/oxi-one-mk2/page/1` → `usePathname()` returns `/oxi-one-mk2/page/1`
-
-### Configuration References
-
-- `next.config.js`: Contains `basePath: '/manuals'`
-- `lib/manual-config.ts`: Helper functions for route and asset paths
+- **Route paths** (`<Link>`, `router.push()`): Don't include `/manuals` prefix - basePath adds it automatically
+- **Static asset paths** (`<img>`, `<a href>`): Don't include `/manuals` prefix - basePath adds it automatically
+- **App directory**: Routes defined WITHOUT `/manuals` prefix (`/app/[manualId]/page/[pageNum]/page.tsx` serves at `/manuals/[manualId]/page/[pageNum]`)
+- **usePathname()**: Returns paths WITHOUT basePath
+- **Configuration**: `next.config.js` (basePath), `lib/manual-config.ts` (helper functions)
 
 ## Language Guidelines
 
-**Development Language: English**
+**Development Language: English** - All communication, GitHub issues/PRs, commit messages, code comments, documentation
 
-- All communication with Claude Code should be in **English**
-- GitHub issues, PRs, commit messages, and code comments: **English**
-- Documentation (CLAUDE.md, README.md, code documentation): **English**
-- Technical discussions and planning: **English**
+**Application Language: Japanese** - UI text, translations, user-facing content (`lang="ja"`)
 
-**Application Language: Japanese**
+**Rationale:** English for development ensures accessibility for international collaboration while keeping the end-user experience fully localized for Japanese users.
 
-- The app itself is for Japanese users
-- HTML lang attribute: `lang="ja"`
-- UI text, translations, and user-facing content: **Japanese**
-- Manual translations: **Japanese**
-
-**Rationale:** This project may collaborate with international developers or be referenced globally. Using English for development ensures accessibility while keeping the end-user experience fully localized for Japanese users.
-
-## Security Notes
+## Security & Command Restrictions
 
 - **NEVER use `rm -rf` with absolute paths** - Always use relative paths like `rm -rf ./foo/bar`
-- Using `rm -rf /foo/bar/` will be denied by security systems
-- Always verify paths before deletion operations
+- **Never use force push** - Force push can destroy commit history
+- **Don't use `git commit --amend`** - Only with explicit user permission
+- **Don't reuse branch names** - Always make new branch names for each PR
+- **Default merge strategy**: Regular merge (NOT squash) unless explicitly requested
 
-## Temporary Files and Reports (`__inbox/` directory)
+## Temporary Files (`__inbox/`)
 
-The `__inbox/` directory serves as a temporary stash for:
-
-- Processing reports and logs
-- Translation work-in-progress files
-- Screenshots and test outputs
-- Any generated reports that shouldn't be committed to Git
-- Error reports from processing
-- Temporary analysis files
-
-**Key points:**
-
-- This directory is in `.gitignore` - files here won't be committed
-- Safe place for temporary work files and reports
-- **ALWAYS use `__inbox/` for temporary files** - Do NOT save temporary files (screenshots, test outputs, etc.) to the repository root
-- Processing errors are saved here with timestamps
-- Claude can freely create temporary files here for analysis
-
-Example files saved here:
-
-- `translation-errors-YYYY-MM-DD-HH-mm-ss.json` - Error reports from translation processing
-- `test-screenshot.png` - Temporary test screenshots
-- Analysis reports and temporary documentation
-- Any other temporary files needed during development
+All temporary files (reports, screenshots, test outputs, error reports) go to `__inbox/` (gitignored). Never save temporary files to the repository root.
 
 ## Directory Structure
 
 ```
 /
 ├── app/                        # Next.js app directory
-│   └── page/                   # Continuous page viewer (/page/[1-280])
 ├── components/                 # React components
 ├── lib/                        # Utilities and libraries
-│   ├── manual-data.ts          # Data loading logic
-│   └── types/                  # TypeScript type definitions
 ├── public/                     # Static assets
-│   └── manuals/                # Multi-manual structure
-│       └── oxi-one-mk2/        # OXI ONE MKII manual
-│           ├── data/           # Final JSON files (imported at build time)
-│           │   ├── manifest.json
-│           │   └── pages.json
-│           ├── pages/          # Rendered PNG images (150 DPI)
-│           │   ├── page-001.png
-│           │   └── ... (page-272.png)
-│           └── processing/     # Intermediate files (gitignored)
-│               ├── extracted/  # Extracted text from PDF
-│               └── translations-draft/  # Translation drafts
-├── manual-pdf/                 # Source PDFs
-│   ├── pages/                  # Split page PDFs (gitignored)
-│   └── parts/                  # Split part PDFs (gitignored)
-├── scripts/                    # Build and migration scripts
+│   └── oxi-one-mk2/           # OXI ONE MKII manual
+│       ├── data/               # Final JSON files (build time import)
+│       ├── pages/              # Rendered PNG images (150 DPI)
+│       └── processing/         # Intermediate files (gitignored)
+├── manual-pdf/                 # Source PDFs (pages/parts gitignored)
+├── scripts/                    # Build and processing scripts
 ├── doc/                        # Docusaurus documentation
 ├── worktrees/                  # Git worktrees (gitignored)
 └── __inbox/                    # Temporary files (gitignored)
 ```
 
-**Multi-Manual Architecture:**
+Each manual is self-contained under `/public/{manual-id}/` with its own data, images, and processing files.
 
-- Each manual is self-contained under `/public/{manual-id}/`
-- Final data (JSON + images) committed to repository
-- Processing files are gitignored (can delete after successful deploy)
-- Ready for adding more manuals with same structure
+## Package Manager & Technology Stack
 
-## Command Restrictions
+This project uses **pnpm** (workspace in `pnpm-workspace.yaml`).
 
-### rm -rf
-
-Never use `rm -rf` from the root directory. Always use relative paths.
-
-**❌ WRONG:**
-
-```bash
-rm -rf /Users/takazudo/repos/path/to/file.md
-```
-
-**✅ CORRECT:**
-
-```bash
-rm -rf ./path/to/file.md
-```
-
-### Git Related
-
-- **Never use force push** - Force push can destroy commit history and cause data loss
-- **Don't use `git commit --amend`** - Only use with explicit user permission for special cases
-- **Don't create the same branch name PR** - Always make new branch names for each PR to avoid confusion
-
-#### Merge Strategy
-
-**Default: Regular Merge (NOT Squash)**
-
-Use regular merge for PRs unless explicitly requested otherwise:
-
-```bash
-# ✅ CORRECT (default)
-gh pr merge <PR_NUMBER>
-
-# ❌ ONLY use squash when specifically requested
-gh pr merge <PR_NUMBER> --squash
-```
-
-## Git Worktree Workflow
-
-We use git worktrees under the `worktrees/{tree-name}/` directory for topic-based development.
-
-### 🚨 CRITICAL WARNING: Always Check Your Current Directory Before Git Operations
-
-**MANDATORY CHECK BEFORE ANY GIT OPERATION:**
-
-```bash
-# ALWAYS run this before ANY git operation (commit, push, checkout, branch, etc.)
-pwd
-```
-
-**If the output contains `/worktrees/`:**
-
-- ❌ **STOP! You are in a git worktree!**
-- ❌ **Any git operation will affect the WORKTREE BRANCH, not main!**
-- ✅ **Navigate back to repo root first:** `cd /Users/takazudo/repos/personal/manual-oxi-one-mk2`
-
-### 🔴 Two Different Session Contexts
-
-#### Context 1: Root Session (Manager Role)
-
-**Started from:** `/Users/takazudo/repos/personal/manual-oxi-one-mk2/` (repo root)
-**Purpose:** Manage project, review work, merge PRs
-**Git operations:** Affect `main` branch
-**RULE:** Never cd into `/worktrees/{slug}/` and do git operations
-
-#### Context 2: Worktree Session (Worker Role)
-
-**Started from:** `/Users/takazudo/repos/personal/manual-oxi-one-mk2/worktrees/{slug}/`
-**Purpose:** Work on specific issue/task
-**Git operations:** Affect the worktree's feature branch (e.g., `issue-3--docusaurus-...`)
-**RULE:** All work happens here, commits go to feature branch
-
-### 🚨 CRITICAL WARNING: NEVER Mix Contexts
-
-**If you started in ROOT (manager session):**
-
-- ❌ **NEVER** cd into `/worktrees/{slug}/` and do git operations
-- ✅ **DO** read files from worktrees for reference
-- ✅ **DO** review PRs, merge branches, manage the project
-
-**If you started in WORKTREE (worker session):**
-
-- ✅ All your work happens here
-- ✅ Commits and pushes go to the feature branch
-- ✅ When done, create PR to merge into main
-
-### Common Mistake Example
-
-```bash
-# ❌ WRONG - This is a disaster waiting to happen:
-# (Started session in repo root)
-pwd                           # /Users/.../manual-oxi-one-mk2
-cd worktrees/issue-3-docusaurus/
-git add .
-git commit -m "fix"          # ❌ Commits to issue-3 branch, NOT main!
-git push                     # ❌ Pushes to wrong branch!
-
-# ✅ CORRECT - Always check where you are:
-pwd                           # /Users/.../manual-oxi-one-mk2
-# If you need to work on issue-3, start a NEW session in that worktree
-# Don't cd there from root session!
-```
-
-### How to Detect You're in a Worktree
-
-**Method 1: Check current path**
-```bash
-pwd
-# If output contains '/worktrees/', you're in a worktree
-```
-
-**Method 2: Check git branch**
-```bash
-git branch --show-current
-# If it shows 'issue-X--something', you're likely in a worktree
-# If it shows 'main', you're in the main repo
-```
-
-**Method 3: Check worktree list**
-```bash
-git worktree list
-# Shows all active worktrees and their branches
-```
-
-### 🛑 BEFORE ANY GIT COMMAND: Checklist
-
-Before running ANY of these commands:
-
-- `git add`
-- `git commit`
-- `git push`
-- `git checkout`
-- `git branch`
-- `git merge`
-
-**RUN THIS FIRST:**
-```bash
-pwd
-# Confirm you're in the correct location!
-# Repo root: /Users/takazudo/repos/personal/manual-oxi-one-mk2
-# Worktree: /Users/takazudo/repos/personal/manual-oxi-one-mk2/worktrees/{slug}
-```
-
-**Then ask yourself:**
-
-- "Am I in the right context for this operation?"
-- "Is this what I intend to do?"
-- "Will this affect the correct branch?"
-
-### What Happens When You Make a Mistake
-
-**Scenario:** You started in root, cd'd to worktree, and committed
-
-- ✅ The commit goes to the worktree's feature branch
-- ❌ The commit does NOT go to main
-- ❌ You might have committed to the wrong issue's branch
-- ❌ Very hard to debug and fix
-- ❌ Wastes time and causes confusion
-
-**Prevention:** ALWAYS check `pwd` before git operations!
-
-### ⚠️ CRITICAL: Always Pull Before Creating Worktree
-
-**MANDATORY**: Pull the latest base branch before creating a worktree to ensure it includes all merged changes.
-
-```bash
-# ✅ CORRECT - Pull first, then create worktree
-git checkout main
-git pull origin main
-pnpm run init-worktree issue-3-docusaurus
-
-# ❌ WRONG - Creating worktree from stale local branch
-pnpm run init-worktree issue-3-docusaurus  # Missing merged PRs!
-```
-
-**Why this matters:**
-
-- Worktrees created from stale branches are missing merged PRs
-- Implementation sessions fail due to missing dependencies
-- Wasted time reimplementing code that already exists
-- Confusion about what files should exist
-
-**Example of what goes wrong:**
-
-1. PR #14 merged to remote `main` ✅
-2. Local `main` not updated ❌
-3. Worktree created from stale local branch ❌
-4. Worktree missing all PR #14 files ❌
-5. Implementation fails ❌
-
-**Always follow this sequence:**
-
-1. Merge any pending PRs
-2. Pull latest base branch
-3. Create worktree
-4. Verify worktree has expected files
-
-### init-worktree Command
-
-We have an `init-worktree` command that will set up a git worktree automatically.
-
-**Usage:**
-
-```bash
-pnpm run init-worktree <worktree-name>
-```
-
-**What it does:**
-
-1. Creates `worktrees/<worktree-name>` using `git worktree add` (if it doesn't exist)
-2. Sets up symbolic links for environment files from the repo root
-3. Ensures environment settings are shared across worktrees
-
-**Example:**
-
-```bash
-# Create and initialize a worktree for a new feature
-pnpm run init-worktree issue-2-project-setup
-
-# This creates worktrees/issue-2-project-setup/ with all environment files linked
-```
-
-### ⚠️ CRITICAL: Always Pull Before Creating Worktree
-
-**MANDATORY**: Pull the latest base branch before creating a worktree to ensure it includes all merged changes.
-
-```bash
-# ✅ CORRECT - Pull first, then create worktree
-git checkout main
-git pull origin main
-pnpm run init-worktree issue-2-project-setup
-
-# ❌ WRONG - Creating worktree from stale local branch
-pnpm run init-worktree issue-2-project-setup  # Missing merged PRs!
-```
-
-## Localhost Port Mapping for Development
-
-This port mapping is crucial for human-to-AI communication. When users reference localhost URLs (e.g., "check http://zmanuals.localhost:3100/"), use this mapping to understand which service and files are being referenced.
-
-### Port Assignment Table
-
-| Port | Service          | Domain                          | Directory | Purpose                     | Start Command    |
-| ---- | ---------------- | ------------------------------- | --------- | --------------------------- | ---------------- |
-| 3100 | Next.js App      | `zmanuals.localhost`            | `/`       | Manual viewer app           | `pnpm dev`       |
-| 3100 | Docusaurus Docs  | `doc-zmanuals.localhost`        | `/doc/`   | Technical documentation     | `pnpm doc:dev`   |
-| 8030 | Production Build | `localhost`                     | `/out/`   | Production build test serve | `pnpm serve`     |
-
-### URL to File Mapping Examples
-
-- `http://zmanuals.localhost:3100/manuals/oxi-one-mk2/` → Next.js app in `/app/`
-- `http://zmanuals.localhost:3100/manuals/oxi-one-mk2/page/1` → Manual page viewer
-- `http://doc-zmanuals.localhost:3100/docs/inbox/` → Documentation in `/doc/docs/inbox/`
-
-### Port Management
-
-**Automatic port cleanup:**
-
-- Use `lsof -ti:[PORT] | xargs kill -9` for manual cleanup if needed
-- Example: `lsof -ti:3100 | xargs kill -9`
+- **Next.js 14+** (App Router, static export) | **React 19** | **TypeScript**
+- **Tailwind CSS v4** with Zudo Design System | **Docusaurus 3** for docs
+- **JSON** for translation data | **PNG** for rendered PDF pages (150 DPI)
 
 ## Development Commands
 
 ```bash
-# Start development server (Next.js)
-pnpm dev
+# App development
+pnpm dev                # Start Next.js dev server
+pnpm build              # Build for production
+pnpm serve              # Serve production build locally
 
-# Start documentation server (Docusaurus)
-pnpm doc:dev
+# Documentation (see doc/CLAUDE.md for details)
+pnpm doc:dev            # Start Docusaurus dev server
+pnpm doc:build          # Build documentation
 
-# Build for production
-pnpm build
-
-# Build documentation
-pnpm doc:build
-
-# Serve production build locally
-pnpm serve
-
-# PDF Processing (Issue #21)
-pnpm run pdf:split       # Split PDF into parts
-pnpm run pdf:render      # Render pages to PNG images
-pnpm run pdf:extract     # Extract text from PDFs
-pnpm run pdf:translate   # Translate to Japanese (requires ANTHROPIC_API_KEY)
-pnpm run pdf:build       # Build final JSON files
-pnpm run pdf:manifest    # Create manifest.json
-pnpm run pdf:all         # Run all PDF processing steps
-
-# Type checking
-pnpm typecheck
-
-# Linting
-pnpm lint
-pnpm lint:fix
-
-# Formatting
-pnpm format
-pnpm format:fix
-
-# Run all checks before committing
-pnpm check
-pnpm check:fix
-
-# Clean build outputs
-pnpm clean
+# Quality
+pnpm typecheck          # Type checking
+pnpm lint               # Linting (lint:fix to auto-fix)
+pnpm format             # Formatting (format:fix to auto-fix)
+pnpm check              # Run all checks (check:fix to auto-fix)
+pnpm test               # Run tests
+pnpm clean              # Clean build outputs
 ```
 
-## PDF Processing Automation
-
-**Claude Code Skill:** `/l-pdf-process`
-
-Automated workflow for converting the OXI ONE MKII PDF manual into Next.js application data using Claude Code Task subagents.
-
-### ⚠️ Important: Maintain the System, Not the Output
-
-**Critical Principle:** Translation output files (extracted text, translation drafts, final JSON) are **temporary generated files**. What we maintain and improve is the **system itself**:
-
-✅ **Maintain:**
-
-- Translator prompt (`.claude/agents/manual-translator.md`)
-- Processing scripts (`scripts/pdf-*.js`)
-- Command documentation (`.claude/skills/pdf-process/SKILL.md`)
-- Pipeline configuration (`pdf-config.json`)
-
-❌ **Don't maintain (regenerate as needed):**
-
-- `public/oxi-one-mk2/processing/extracted/` - Extracted text files
-- `public/oxi-one-mk2/processing/translations-draft/` - Translation work-in-progress
-- `public/oxi-one-mk2/data/` - Final JSON output
-- `public/oxi-one-mk2/pages/` - Rendered images
-- `manual-pdf/pages/` - Split page PDFs
-- `manual-pdf/parts/` - Split part PDFs
-
-**When improving translation quality:** Update the translator prompt in `.claude/agents/manual-translator.md`, then regenerate outputs by running the pipeline again. The outputs are disposable - the process is what matters.
-
-### Quick Start
-
-```bash
-# 1. Place PDF in manual-pdf directory
-cp /path/to/OXI-ONE-MKII-Manual.pdf manual-pdf/
-
-# 2. Run full pipeline via Claude Code
-# Type: /l-pdf-process
-```
-
-**Claude Code will execute the pipeline without asking questions during translation.**
-
-### Pipeline Overview
-
-The PDF processing pipeline consists of 6 fully automated steps:
-
-1. **Split** - Divides the PDF into parts (30 pages each)
-2. **Render** - Converts pages to PNG images at 150 DPI
-3. **Extract** - Extracts text from each PDF part
-4. **Translate** - Translates to Japanese using Claude Code Task subagents (5 concurrent workers)
-5. **Build** - Combines data into JSON files for Next.js
-6. **Manifest** - Creates manifest.json with metadata
-
-**Total time:** ~15-30 minutes for a 280-page manual
-
-### Output Structure
-
-```
-manual-pdf/
-  ├── pages/                                    # Split page PDFs (gitignored)
-  └── parts/                                    # Split part PDFs (gitignored)
-public/oxi-one-mk2/
-  ├── data/                                     # Final JSON files (for Next.js)
-  │   ├── manifest.json
-  │   └── pages.json
-  ├── pages/                                    # Rendered PNG images (150 DPI)
-  │   ├── page-001.png
-  │   └── ... (page-272.png)
-  └── processing/                               # Intermediate files (gitignored)
-      ├── extracted/                            # Extracted text
-      └── translations-draft/                   # Translation drafts
-```
-
-### Configuration
-
-Edit `pdf-config.json` to customize settings:
-
-- Image DPI and format
-- Translation model
-- Max retries
-
-### Cost Estimation
-
-Translation using Claude Sonnet 4.5:
-
-- Estimated: $5-10 per full 280-page manual
-- Time: 15-30 minutes total
-
-### Error Handling
-
-- Error reports saved to `__inbox/`
-- Scripts can be resumed from failed step
-- Retry logic for API failures
-
-### Translation Verification
-
-**Claude Code Command:** `/l-verify-translation`
-
-After running the PDF processing pipeline, use this command to verify that translations match the page images.
-
-**What it does:**
-
-1. Starts dev server on port 3100 (if not running)
-2. Captures all 30 pages at high resolution (2000x1600) using `capture-all-pages` skill
-3. Verifies sample pages (1, 10, 15, 21, 30) for translation accuracy
-4. Checks for:
-   - ✅ Translation is present
-   - ✅ Page numbers match
-   - ✅ Content corresponds to image
-   - ❌ No missing translations
-   - ❌ No page number mismatches
-5. Generates verification report
-
-**Usage:**
-
-```bash
-# Ensure dev server is running
-pnpm dev
-
-# Run verification command
-/l-verify-translation
-```
-
-**Output location:** `__inbox/captures-{date}-{session}/`
-
-**Project-Specific Skill:** `capture-all-pages`
-
-This skill captures screenshots of all manual pages at high resolution for visual verification.
-
-- **Resolution:** 2000x1600 (high detail for inspection)
-- **Pages:** All 30 pages (or configured total)
-- **Output:** `__inbox/captures-{YYYYMMDD}-{session}/`
-- **Format:** PNG files named `page-001.png` to `page-030.png`
-
-The skill embeds Playwright logic directly and saves captures to the project's `__inbox/` directory (gitignored).
-
-**Full Documentation:** See `scripts/README-PDF-PROCESSING.md`
-
-## Multi-Manual Support
-
-The system supports multiple PDF manuals with unique slugs. Each manual is self-contained under `/public/{manual-id}/` with its own data, images, and processing files.
-
-### Architecture
-
-**Directory structure per manual:**
-
-```
-/manual-pdf/{slug}/              # Source PDF directory
-  └── *.pdf                      # Any PDF file (first one found is used)
-
-/public/{slug}/          # Output directory
-  ├── data/                      # Final JSON files (committed)
-  │   ├── manifest.json
-  │   └── pages.json
-  ├── pages/                     # Rendered images (committed)
-  │   ├── page-001.png
-  │   └── ... (page-XXX.png)
-  └── processing/                # Intermediate files (gitignored)
-      ├── extracted/
-      └── translations-draft/
-```
-
-**URL structure:**
-
-- Base: `/manuals/{slug}/`
-- Pages: `/manuals/{slug}/page/{pageNum}`
-- Examples:
-  - `/manuals/oxi-one-mk2/page/1`
-  - `/manuals/oxi-coral/page/1`
-
-### Adding a New Manual
-
-**Step-by-step workflow:**
-
-1. **Create source directory:**
-   ```bash
-   mkdir manual-pdf/{slug}
-   ```
-
-2. **Add PDF file** (any filename works):
-   ```bash
-   cp ~/path/to/manual.pdf manual-pdf/{slug}/
-   ```
-
-3. **Process the PDF:**
-   ```bash
-   /l-pdf-process {slug}
-   ```
-   This runs all 6 pipeline steps: split, render, extract, translate, build, manifest.
-
-4. **Update manual registry** (`lib/manual-registry.ts`):
-
-   Add imports for the new manual:
-   ```typescript
-   import newManualManifest from '@/public/new-manual/data/manifest.json';
-   import newManualPages from '@/public/new-manual/data/pages.json';
-
-   const MANUAL_REGISTRY: Record<string, ManualRegistryEntry> = {
-     'new-manual': {
-       manifest: newManualManifest as unknown as ManualManifest,
-       pages: newManualPages as unknown as ManualPagesData,
-     },
-   };
-   ```
-
-   **Why explicit imports?** This approach ensures:
-
-   - Type safety with TypeScript
-   - Build-time bundling (no runtime fetch)
-   - Compatible with Next.js static export (`output: 'export'`)
-
-5. **Build and deploy:**
-   ```bash
-   pnpm build
-   ```
-
-**Time estimate:** ~30 minutes (excluding translation time ~15-30 min)
-
-### Processing Multiple Manuals
-
-All PDF processing scripts accept a `--slug` parameter:
-
-```bash
-# Process specific manual
-pnpm run pdf:all --slug oxi-one-mk2
-pnpm run pdf:all --slug oxi-coral
-
-# Individual steps
-pnpm run pdf:split --slug oxi-coral
-pnpm run pdf:render --slug oxi-coral
-pnpm run pdf:extract --slug oxi-coral
-pnpm run pdf:translate --slug oxi-coral
-pnpm run pdf:build --slug oxi-coral
-pnpm run pdf:manifest --slug oxi-coral
-```
-
-**Configuration:**
-
-- All paths computed from slug (no config files needed)
-- Source PDF: `/manual-pdf/{slug}/*.pdf` (first PDF found)
-- Output: `/public/{slug}/`
-- Settings: `pdf-config.json` (shared across all manuals)
-
-### Important Notes
-
-**Manual Registry is Manual:**
-
-- The registry (`lib/manual-registry.ts`) requires explicit imports for each manual
-- This is NOT automatic - you must add imports for each new manual
-- The build will fail if imports are missing
-- This ensures type safety and build-time optimization
-
-**Processing Files are Temporary:**
-
-- Only `data/` and `pages/` directories are committed
-- `processing/` directory is gitignored
-- Can delete processing files after successful deploy
-
-**Backward Compatibility:**
-
-- Existing manual URLs unchanged: `/manuals/oxi-one-mk2/page/1`
-- Each manual is independent
-- No conflicts between manuals
-
-## Package Manager
-
-This project uses **pnpm** for package management.
-
-- All dependencies are managed via pnpm
-- Workspace configuration in `pnpm-workspace.yaml`
-- Sub-packages are defined in the workspace
-
-## Technology Stack
-
-### Core Technologies
-
-- **Next.js 14+**: App Router for server-side rendering and static generation
-- **React 19**: UI framework
-- **TypeScript**: Type safety
-- **Tailwind CSS v4**: Styling with custom design system (Zudo Design System)
-- **pnpm**: Package manager with workspace support
-
-### Documentation
-
-- **Docusaurus 3**: Technical documentation system
-- **Japanese locale**: Default language for documentation
-
-### Data & Content
-
-- **JSON**: Translation data storage
-- **Markdown/MDX**: Translation content format
-- **PNG Images**: Rendered PDF pages (150 DPI)
+For PDF processing commands (`pdf:split`, `pdf:render`, etc.), see `scripts/CLAUDE.md`.
 
 ## Design System (Zudo Design System)
 
-This project uses the Zudo Design System, a custom Tailwind CSS v4 configuration with:
-
-- **All Tailwind defaults disabled** - Only Zudo tokens available
-- **CSS Variables**: Comprehensive token system in `:root`
-- **Semantic naming**: `hgap` (horizontal) and `vgap` (vertical) spacing
-- **Custom utilities**: Defined via `@utility` directive
-- **Dark theme**: Default and enforced
-
-See `/doc/docs/inbox/design-system.md` for comprehensive documentation.
-
-## Data Structure
-
-Each manual has two JSON files: manifest.json (metadata) and pages.json (all pages):
-
-### Directory Structure
-
-```
-/public/oxi-one-mk2/data/
-├── manifest.json         # Master index with metadata
-└── pages.json            # All pages in single array
-```
-
-### How Data is Loaded
-
-**Build-time import (Current Approach):**
-
-- JSON files imported as ES modules in `lib/manual-registry.ts`
-- Data bundled into HTML at build time
-- Compatible with Next.js static export (`output: 'export'`)
-- Fast page loads (no runtime fetch)
-
-```typescript
-// lib/manual-registry.ts
-import oxiOneMk2Manifest from '@/public/oxi-one-mk2/data/manifest.json';
-import oxiOneMk2Pages from '@/public/oxi-one-mk2/data/pages.json';
-```
-
-### Manifest Format (`manifest.json`)
-
-```json
-{
-  "title": "OXI ONE MKII: Manual",
-  "brand": "OXI Instruments",
-  "version": "1.0.0",
-  "totalPages": 272,
-  "contentPages": 260,
-  "lastUpdated": "2026-01-12T...",
-  "source": {
-    "filename": "OXI-ONE-MKII-Manual.pdf",
-    "processedAt": "2026-01-12T...",
-    "imageDPI": 300,
-    "imageFormat": "png"
-  }
-}
-```
-
-### Pages Format (`pages.json`)
-
-```json
-{
-  "metadata": {
-    "processedAt": "2026-01-12T...",
-    "translationMethod": "claude-code-subagent-page-by-page",
-    "imageFormat": "png",
-    "imageDPI": 300
-  },
-  "pages": [
-    {
-      "pageNum": 1,
-      "image": "/oxi-one-mk2/pages/page-001.png",
-      "title": "Page 1",
-      "sectionName": null,
-      "translation": "# Markdown content here...",
-      "hasContent": true,
-      "tags": []
-    }
-  ]
-}
-```
-
-## Important: Pre-Push Checklist
-
-**ALWAYS run these commands before pushing to GitHub:**
-
-1. **Run all quality checks:**
-
-   ```bash
-   pnpm check
-   ```
-
-2. **If there are issues, fix them:**
-
-   ```bash
-   pnpm check:fix
-   ```
-
-3. **Run tests (optional but recommended):**
-   ```bash
-   pnpm test
-   ```
-
-## Japanese Text Guidelines
-
-- **Target audience**: Japanese users
-- **Translation style**: Technical documentation style (です・ます調)
-- **Terminology**: Preserve technical terms in English where appropriate (e.g., MIDI, CV, Sequencer)
-- **Consistency**: Maintain consistent translation of terms across all parts
-
-## GitHub Issues
-
-All major features and tasks are tracked as GitHub issues:
-
-- #1: Technical Documentation (page-by-page PDF translation system)
-- #2: Project Setup & Infrastructure
-- #3: Docusaurus Documentation System Setup
-- #4: Tailwind CSS Design System Setup
-- #5: Next.js App with Part 01 Viewer (MVP)
-- #6: Data Migration: HTML to Next.js JSON Structure
-- #7: Convert All Manual Parts (Parts 02-10)
-- #8: Search Functionality
-- #9: Bookmarking & Progress Tracking
-- #10: Performance Optimizations
-- #11: Deployment Setup
-
-## Reference Project
-
-This project is based on the architecture and design system from:
-`/Users/takazudo/repos/personal/takazudomodular`
-
-Key learnings and patterns are adapted from this reference project.
+Custom Tailwind CSS v4 config: all defaults disabled, only Zudo tokens. CSS variables in `:root`, semantic naming (`hgap`/`vgap`), dark theme enforced. See `/doc/docs/inbox/design-system.md`.
 
 ## Coding Standards
 
 ### TypeScript
 
-- Use strict type checking
-- Define interfaces for all data structures
-- Avoid `any` type unless absolutely necessary
+- Strict type checking, define interfaces for all data structures, avoid `any`
 
 ### React Components
 
-- Prefer functional components with hooks
-- Use proper prop types or TypeScript interfaces
-- Keep components focused and single-purpose
+- Functional components with hooks, proper prop types/interfaces, single-purpose
 
 ### Styling
 
@@ -913,33 +128,65 @@ Key learnings and patterns are adapted from this reference project.
 
 ### File Naming
 
-- Use kebab-case for all file names
-- Example: `page-viewer.tsx`, `translation-panel.tsx`
+- Use kebab-case for all file names (e.g., `page-viewer.tsx`, `translation-panel.tsx`)
 
-## Quality Assurance
+## Quality Assurance & Pre-Push Checklist
 
-### Pre-commit Checks
+**Pre-commit checks**: ESLint, Prettier, TypeScript type checking
+**CI/CD**: Automated builds, type checking, linting, formatting, tests, build verification on every PR
 
-- ESLint on JavaScript/TypeScript files
-- Prettier on all supported file types
-- TypeScript type checking
+**ALWAYS run before pushing:**
 
-### CI/CD
+```bash
+pnpm check          # Run all quality checks
+pnpm check:fix      # Fix issues if any
+pnpm test           # Run tests (recommended)
+```
 
-- Automated builds on every PR
-- Type checking
-- Linting and formatting checks
-- Test execution
-- Build verification
+## Git Worktree Workflow
 
-## Documentation
+We use git worktrees under `worktrees/{tree-name}/` for topic-based development.
 
-Comprehensive project documentation is maintained in `/doc/` using Docusaurus.
+**Critical rules:**
 
-- **INBOX category**: Main development documentation
-- **Japanese locale**: All documentation in Japanese
-- **Dark mode**: Forced dark theme for consistency
+- **Always check `pwd` before any git operation** to confirm you're in the correct context
+- **Root session (manager)**: Never cd into worktrees for git operations
+- **Worktree session (worker)**: All work stays in the worktree, commits go to feature branch
+- **Always pull before creating a worktree**: `git pull origin main` first
+- **Use `pnpm run init-worktree <name>`** to set up worktrees with correct env links
 
-## Contact & Support
+For detailed worktree workflow, examples, and troubleshooting, see `.claude/CLAUDE.md`.
 
-For questions or issues related to this project, refer to the GitHub issues or project documentation.
+## Localhost Port Mapping
+
+| Port | Service          | Domain                   | Purpose                     | Start Command |
+| ---- | ---------------- | ------------------------ | --------------------------- | ------------- |
+| 3100 | Next.js App      | `zmanuals.localhost`     | Manual viewer app           | `pnpm dev`    |
+| 3100 | Docusaurus Docs  | `doc-zmanuals.localhost` | Technical documentation     | `pnpm doc:dev`|
+| 8030 | Production Build | `localhost`              | Production build test serve | `pnpm serve`  |
+
+Port cleanup: `lsof -ti:[PORT] | xargs kill -9`
+
+## Japanese Text Guidelines
+
+- **Target audience**: Japanese users (です・ます調)
+- Preserve technical terms in English (MIDI, CV, Sequencer)
+- Maintain consistent terminology across all parts
+
+## GitHub Issues
+
+- #1: Technical Documentation | #2: Project Setup | #3: Docusaurus Setup
+- #4: Tailwind CSS Design System | #5: Next.js App MVP | #6: Data Migration
+- #7: Convert All Parts | #8: Search | #9: Bookmarking | #10: Performance | #11: Deployment
+
+## Reference Project
+
+Based on architecture from `/Users/takazudo/repos/personal/takazudomodular`.
+
+## Subdirectory CLAUDE.md Files
+
+Detailed context-specific instructions are in subdirectory CLAUDE.md files (loaded automatically when working in those directories):
+
+- **`scripts/CLAUDE.md`** - PDF processing pipeline, multi-manual support, data structure formats
+- **`doc/CLAUDE.md`** - Docusaurus documentation setup and conventions
+- **`.claude/CLAUDE.md`** - Git worktree workflow details, Claude Code skills/agents overview

--- a/doc/CLAUDE.md
+++ b/doc/CLAUDE.md
@@ -1,0 +1,42 @@
+# Documentation (Docusaurus) - CLAUDE.md
+
+Docusaurus documentation system configuration. For project-wide instructions, see the root `CLAUDE.md`.
+
+## Overview
+
+Comprehensive project documentation is maintained in `/doc/` using Docusaurus 3.
+
+- **INBOX category**: Main development documentation (in `doc/docs/inbox/`)
+- **Japanese locale**: All documentation in Japanese (default language)
+- **Dark mode**: Forced dark theme for consistency with the main app
+
+## Development Commands
+
+```bash
+pnpm doc:dev            # Start Docusaurus dev server (port 3100, doc-zmanuals.localhost)
+pnpm doc:build          # Build documentation for production
+```
+
+## URL Mapping
+
+- `http://doc-zmanuals.localhost:3100/docs/inbox/` maps to files in `/doc/docs/inbox/`
+
+## Structure
+
+```
+doc/
+├── docs/
+│   └── inbox/              # Main documentation category
+├── docusaurus.config.ts    # Docusaurus configuration
+├── package.json            # Doc-specific dependencies
+├── plugins/                # Custom Docusaurus plugins
+├── scripts/                # Doc build scripts
+├── sidebars.ts             # Sidebar configuration
+├── src/                    # Custom components and pages
+├── static/                 # Static assets for documentation
+└── tsconfig.json           # TypeScript config
+```
+
+## Design System Documentation
+
+The Zudo Design System documentation is at `/doc/docs/inbox/design-system.md`. This is the authoritative reference for the custom Tailwind CSS v4 configuration used in the main app.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,337 @@
+# Scripts - CLAUDE.md
+
+PDF processing scripts and multi-manual support documentation. For project-wide instructions, see the root `CLAUDE.md`.
+
+## PDF Processing Automation
+
+**Claude Code Skill:** `/l-pdf-process`
+
+Automated workflow for converting PDF manuals into Next.js application data using Claude Code Task subagents.
+
+### Important: Maintain the System, Not the Output
+
+Translation output files are **temporary generated files**. What we maintain is the **system itself**:
+
+**Maintain:**
+
+- Translator prompt (`.claude/agents/manual-translator.md`)
+- Processing scripts (`scripts/pdf-*.js`)
+- Command documentation (`.claude/skills/pdf-process/SKILL.md`)
+- Pipeline configuration (`pdf-config.json`)
+
+**Don't maintain (regenerate as needed):**
+
+- `public/oxi-one-mk2/processing/extracted/` - Extracted text files
+- `public/oxi-one-mk2/processing/translations-draft/` - Translation work-in-progress
+- `public/oxi-one-mk2/data/` - Final JSON output
+- `public/oxi-one-mk2/pages/` - Rendered images
+- `manual-pdf/pages/` - Split page PDFs
+- `manual-pdf/parts/` - Split part PDFs
+
+**When improving translation quality:** Update the translator prompt in `.claude/agents/manual-translator.md`, then regenerate outputs by running the pipeline again.
+
+### Quick Start
+
+```bash
+# 1. Place PDF in manual-pdf directory
+cp /path/to/OXI-ONE-MKII-Manual.pdf manual-pdf/
+
+# 2. Run full pipeline via Claude Code
+# Type: /l-pdf-process
+```
+
+Claude Code will execute the pipeline without asking questions during translation.
+
+### PDF Processing Commands
+
+```bash
+pnpm run pdf:split       # Split PDF into parts
+pnpm run pdf:render      # Render pages to PNG images
+pnpm run pdf:extract     # Extract text from PDFs
+pnpm run pdf:translate   # Translate to Japanese (requires ANTHROPIC_API_KEY)
+pnpm run pdf:build       # Build final JSON files
+pnpm run pdf:manifest    # Create manifest.json
+pnpm run pdf:all         # Run all PDF processing steps
+```
+
+### Pipeline Overview
+
+The PDF processing pipeline consists of 6 fully automated steps:
+
+1. **Split** - Divides the PDF into parts (30 pages each)
+2. **Render** - Converts pages to PNG images at 150 DPI
+3. **Extract** - Extracts text from each PDF part
+4. **Translate** - Translates to Japanese using Claude Code Task subagents (5 concurrent workers)
+5. **Build** - Combines data into JSON files for Next.js
+6. **Manifest** - Creates manifest.json with metadata
+
+**Total time:** ~15-30 minutes for a 280-page manual
+
+### Output Structure
+
+```
+manual-pdf/
+  ├── pages/                                    # Split page PDFs (gitignored)
+  └── parts/                                    # Split part PDFs (gitignored)
+public/oxi-one-mk2/
+  ├── data/                                     # Final JSON files (for Next.js)
+  │   ├── manifest.json
+  │   └── pages.json
+  ├── pages/                                    # Rendered PNG images (150 DPI)
+  │   ├── page-001.png
+  │   └── ... (page-272.png)
+  └── processing/                               # Intermediate files (gitignored)
+      ├── extracted/                            # Extracted text
+      └── translations-draft/                   # Translation drafts
+```
+
+### Configuration
+
+Edit `pdf-config.json` to customize settings:
+
+- Image DPI and format
+- Translation model
+- Max retries
+
+### Cost Estimation
+
+Translation using Claude Sonnet 4.5:
+
+- Estimated: $5-10 per full 280-page manual
+- Time: 15-30 minutes total
+
+### Error Handling
+
+- Error reports saved to `__inbox/`
+- Scripts can be resumed from failed step
+- Retry logic for API failures
+
+### Translation Verification
+
+**Claude Code Command:** `/l-verify-translation`
+
+After running the PDF processing pipeline, use this command to verify that translations match the page images.
+
+**What it does:**
+
+1. Starts dev server on port 3100 (if not running)
+2. Captures all 30 pages at high resolution (2000x1600) using `capture-all-pages` skill
+3. Verifies sample pages (1, 10, 15, 21, 30) for translation accuracy
+4. Checks for:
+  - Translation is present
+  - Page numbers match
+  - Content corresponds to image
+  - No missing translations
+  - No page number mismatches
+5. Generates verification report
+
+**Usage:**
+
+```bash
+# Ensure dev server is running
+pnpm dev
+
+# Run verification command
+/l-verify-translation
+```
+
+**Output location:** `__inbox/captures-{date}-{session}/`
+
+**Project-Specific Skill:** `capture-all-pages`
+
+This skill captures screenshots of all manual pages at high resolution for visual verification.
+
+- **Resolution:** 2000x1600 (high detail for inspection)
+- **Pages:** All 30 pages (or configured total)
+- **Output:** `__inbox/captures-{YYYYMMDD}-{session}/`
+- **Format:** PNG files named `page-001.png` to `page-030.png`
+
+**Full Documentation:** See `scripts/README-PDF-PROCESSING.md`
+
+## Multi-Manual Support
+
+The system supports multiple PDF manuals with unique slugs. Each manual is self-contained under `/public/{manual-id}/` with its own data, images, and processing files.
+
+### Architecture
+
+**Directory structure per manual:**
+
+```
+/manual-pdf/{slug}/              # Source PDF directory
+  └── *.pdf                      # Any PDF file (first one found is used)
+
+/public/{slug}/                  # Output directory
+  ├── data/                      # Final JSON files (committed)
+  │   ├── manifest.json
+  │   └── pages.json
+  ├── pages/                     # Rendered images (committed)
+  │   ├── page-001.png
+  │   └── ... (page-XXX.png)
+  └── processing/                # Intermediate files (gitignored)
+      ├── extracted/
+      └── translations-draft/
+```
+
+**URL structure:**
+
+- Base: `/manuals/{slug}/`
+- Pages: `/manuals/{slug}/page/{pageNum}`
+- Examples:
+  - `/manuals/oxi-one-mk2/page/1`
+  - `/manuals/oxi-coral/page/1`
+
+### Adding a New Manual
+
+1. **Create source directory:**
+   ```bash
+   mkdir manual-pdf/{slug}
+   ```
+
+2. **Add PDF file** (any filename works):
+   ```bash
+   cp ~/path/to/manual.pdf manual-pdf/{slug}/
+   ```
+
+3. **Process the PDF:**
+   ```bash
+   /l-pdf-process {slug}
+   ```
+   This runs all 6 pipeline steps: split, render, extract, translate, build, manifest.
+
+4. **Update manual registry** (`lib/manual-registry.ts`):
+
+   Add imports for the new manual:
+   ```typescript
+   import newManualManifest from '@/public/new-manual/data/manifest.json';
+   import newManualPages from '@/public/new-manual/data/pages.json';
+
+   const MANUAL_REGISTRY: Record<string, ManualRegistryEntry> = {
+     'new-manual': {
+       manifest: newManualManifest as unknown as ManualManifest,
+       pages: newManualPages as unknown as ManualPagesData,
+     },
+   };
+   ```
+
+   **Why explicit imports?** Type safety, build-time bundling, compatible with Next.js static export (`output: 'export'`).
+
+5. **Build and deploy:**
+   ```bash
+   pnpm build
+   ```
+
+### Processing Multiple Manuals
+
+All PDF processing scripts accept a `--slug` parameter:
+
+```bash
+# Process specific manual
+pnpm run pdf:all --slug oxi-one-mk2
+pnpm run pdf:all --slug oxi-coral
+
+# Individual steps
+pnpm run pdf:split --slug oxi-coral
+pnpm run pdf:render --slug oxi-coral
+pnpm run pdf:extract --slug oxi-coral
+pnpm run pdf:translate --slug oxi-coral
+pnpm run pdf:build --slug oxi-coral
+pnpm run pdf:manifest --slug oxi-coral
+```
+
+**Configuration:**
+
+- All paths computed from slug (no config files needed)
+- Source PDF: `/manual-pdf/{slug}/*.pdf` (first PDF found)
+- Output: `/public/{slug}/`
+- Settings: `pdf-config.json` (shared across all manuals)
+
+### Important Notes
+
+**Manual Registry is Manual:**
+
+- The registry (`lib/manual-registry.ts`) requires explicit imports for each manual
+- This is NOT automatic - you must add imports for each new manual
+- The build will fail if imports are missing
+- This ensures type safety and build-time optimization
+
+**Processing Files are Temporary:**
+
+- Only `data/` and `pages/` directories are committed
+- `processing/` directory is gitignored
+- Can delete processing files after successful deploy
+
+**Backward Compatibility:**
+
+- Existing manual URLs unchanged: `/manuals/oxi-one-mk2/page/1`
+- Each manual is independent
+- No conflicts between manuals
+
+## Data Structure
+
+Each manual has two JSON files: manifest.json (metadata) and pages.json (all pages).
+
+### Data Directory
+
+```
+/public/oxi-one-mk2/data/
+├── manifest.json         # Master index with metadata
+└── pages.json            # All pages in single array
+```
+
+### How Data is Loaded
+
+**Build-time import (Current Approach):**
+
+- JSON files imported as ES modules in `lib/manual-registry.ts`
+- Data bundled into HTML at build time
+- Compatible with Next.js static export (`output: 'export'`)
+- Fast page loads (no runtime fetch)
+
+```typescript
+// lib/manual-registry.ts
+import oxiOneMk2Manifest from '@/public/oxi-one-mk2/data/manifest.json';
+import oxiOneMk2Pages from '@/public/oxi-one-mk2/data/pages.json';
+```
+
+### Manifest Format (`manifest.json`)
+
+```json
+{
+  "title": "OXI ONE MKII: Manual",
+  "brand": "OXI Instruments",
+  "version": "1.0.0",
+  "totalPages": 272,
+  "contentPages": 260,
+  "lastUpdated": "2026-01-12T...",
+  "source": {
+    "filename": "OXI-ONE-MKII-Manual.pdf",
+    "processedAt": "2026-01-12T...",
+    "imageDPI": 300,
+    "imageFormat": "png"
+  }
+}
+```
+
+### Pages Format (`pages.json`)
+
+```json
+{
+  "metadata": {
+    "processedAt": "2026-01-12T...",
+    "translationMethod": "claude-code-subagent-page-by-page",
+    "imageFormat": "png",
+    "imageDPI": 300
+  },
+  "pages": [
+    {
+      "pageNum": 1,
+      "image": "/oxi-one-mk2/pages/page-001.png",
+      "title": "Page 1",
+      "sectionName": null,
+      "translation": "# Markdown content here...",
+      "hasContent": true,
+      "tags": []
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

- Split the 945-line root CLAUDE.md into 4 focused files (~745 total lines, ~200 lines saved from deduplication)
- **Root CLAUDE.md** (~192 lines): Essential project-wide rules (project overview, basePath, security, dev commands, coding standards)
- **scripts/CLAUDE.md** (~337 lines): PDF processing pipeline, multi-manual support, data structure formats
- **doc/CLAUDE.md** (~42 lines): Docusaurus documentation setup and conventions
- **.claude/CLAUDE.md** (~174 lines): Detailed git worktree workflow, Claude Code skills/agents overview

No information was lost — content was redistributed to be closer to the code it describes. Claude Code automatically loads subdirectory CLAUDE.md files when working in those directories.

Changes from original:
- Deduplicated "Always Pull Before Creating Worktree" (appeared twice)
- Removed redundant "Contact & Support" section
- Added cross-references between files

## Test plan

- [ ] Verify root CLAUDE.md is concise and contains essential project-wide info
- [ ] Verify scripts/CLAUDE.md has all PDF processing and multi-manual documentation
- [ ] Verify doc/CLAUDE.md has Docusaurus-specific instructions
- [ ] Verify .claude/CLAUDE.md has detailed worktree workflow and skills info
- [ ] Cross-check: no information from original CLAUDE.md was lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)