### PR TITLE
ci: auto-deploy Cloudflare Pages preview per PR + docs

### DIFF
--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -177,7 +177,6 @@ jobs:
           echo "✅ Build output verified"
 
       - name: Upload build artifacts (for e2e tests)
-        if: startsWith(github.head_ref, 'preview/')
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: nextjs-build-pr-${{ github.event.pull_request.number }}
@@ -297,3 +296,72 @@ jobs:
                 body
               });
             }
+
+  # Job 4: Preview Deploy (Cloudflare Pages) for same-repo PRs
+  preview-deploy:
+    name: Preview Deploy (Cloudflare Pages)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: build-check
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          lfs: false
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: nextjs-build-pr-${{ github.event.pull_request.number }}
+          path: out
+
+      - name: Deploy to Cloudflare Pages Preview
+        id: deploy
+        uses: ./.github/actions/deploy-cloudflare
+        with:
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          branch: pr-${{ github.event.pull_request.number }}
+          commit-hash: ${{ github.event.pull_request.head.sha }}
+          commit-message: 'PR #${{ github.event.pull_request.number }} preview: ${{ github.event.pull_request.head.sha }}'
+
+      - name: Create deployment record
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deploy-url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.HEAD_SHA,
+              environment: 'preview',
+              description: 'PR preview deployment to Cloudflare Pages',
+              production_environment: false,
+              auto_merge: false,
+              required_contexts: []
+            });
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              environment_url: process.env.DEPLOY_URL,
+              description: 'PR preview deployment successful'
+            });
+
+      - name: Log deploy URL
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deploy-url }}
+        run: |
+          echo "Deployed preview URL: $DEPLOY_URL"

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -365,3 +365,74 @@ jobs:
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy-url }}
         run: |
           echo "Deployed preview URL: $DEPLOY_URL"
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deploy-url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const deployUrl = process.env.DEPLOY_URL;
+            const prNumber = process.env.PR_NUMBER;
+            const commitSha = process.env.COMMIT_SHA;
+            const shortSha = commitSha.substring(0, 7);
+
+            const body = [
+              '<!-- cf-preview-pr -->',
+              '**PR Preview Deployed**',
+              '',
+              `URL: ${deployUrl}`,
+              `Full manual: ${deployUrl}/manuals/oxi-one-mk2/`,
+              `Branch: \`pr-${prNumber}\``,
+              `Commit: \`${shortSha}\``
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('<!-- cf-preview-pr -->')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }
+
+      - name: Notify PR preview status
+        if: always()
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deploy-url }}
+          JOB_STATUS: ${{ job.status }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const success = process.env.JOB_STATUS === 'success';
+            const status = success ? 'success' : 'failure';
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_SHA,
+              state: status,
+              target_url: process.env.DEPLOY_URL,
+              description: success ? 'PR preview deployment successful' : 'PR preview deployment failed',
+              context: 'cloudflare/pr-preview'
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ This is a Next.js-based manual viewer for the OXI ONE MKII hardware synthesizer 
 - Full URL: `https://zmanuals.pages.dev/manuals/oxi-one-mk2/`
 - The deployed site reflects the current state of the main branch
 - Preview URLs: `https://<branch>.zmanuals.pages.dev/manuals/oxi-one-mk2/`
+- PR preview URLs: `https://pr-<N>.zmanuals.pages.dev/manuals/oxi-one-mk2/` (auto-deployed on every same-repo PR; URL posted as PR comment)
 
 ## basePath Configuration (Critical Architecture Decision)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Next.js-based manual viewer for hardware synthesizer manuals. Provides a bilin
 
 - **Production**: [https://zmanuals.pages.dev/](https://zmanuals.pages.dev/)
 - **OXI ONE MK2 Manual**: [https://zmanuals.pages.dev/manuals/oxi-one-mk2/](https://zmanuals.pages.dev/manuals/oxi-one-mk2/)
+- **PR Previews**: `https://pr-<N>.zmanuals.pages.dev/manuals/oxi-one-mk2/` (auto-deployed per PR)
 
 ## Tech Stack
 

--- a/doc/docs/inbox/pr-preview-url.md
+++ b/doc/docs/inbox/pr-preview-url.md
@@ -1,0 +1,45 @@
+---
+title: PR Preview URL (Cloudflare Pages)
+sidebar_position: 60
+---
+
+# PR Preview URL (Cloudflare Pages)
+
+Every same-repo pull request gets an automatic Cloudflare Pages preview deployment, plus an opt-in named preview flow for ad-hoc branches. This page documents both flows, their comment markers, and the forked-PR caveat so contributors know what to expect.
+
+## PR preview (automatic)
+
+- Every pull request opened from a branch in this repository gets a preview at:
+  - `https://pr-<N>.zmanuals.pages.dev/manuals/oxi-one-mk2/`
+  - `<N>` is the pull request number (e.g. PR #42 → `https://pr-42.zmanuals.pages.dev/manuals/oxi-one-mk2/`).
+- Deployment runs automatically as the `preview-deploy` job in `.github/workflows/pr-quality-checks.yml` after `build-check` succeeds.
+- A bot comment is posted / updated on the PR with the preview URL. The comment contains the marker `<!-- cf-preview-pr -->`, which the workflow uses to find and update the same comment on subsequent pushes.
+- A commit status is reported under the context `cloudflare/pr-preview`, so the preview link and its success/failure state are visible directly on the PR's Checks panel.
+
+## Named preview (manual)
+
+- Push any branch matching `preview/*` (for example `preview/visual-spike`) to trigger `.github/workflows/preview-deploy.yml`.
+- The resulting preview is published under its Cloudflare Pages branch alias (`https://<branch>.zmanuals.pages.dev/`).
+- If the push originated from a branch that has an open PR, the workflow posts / updates a bot comment with the marker `<!-- cf-preview-branch -->`. This keeps named-preview comments separate from the PR auto-preview comment.
+- Use this flow for design reviews or ad-hoc previews that do not yet have a PR, or that need a stable URL independent of the PR number.
+
+## Forked PRs do not get a preview
+
+- Pull requests from **forks** do not get a Cloudflare Pages preview. This is intentional.
+- GitHub does not expose repository secrets (Cloudflare API token, account ID) to workflows triggered by `pull_request` events from forks, so the deploy step cannot authenticate.
+- The `build-check` job still runs for forked PRs (it does not need secrets). Only the `preview-deploy` job is skipped.
+- If a fork contribution needs a live preview, a maintainer can push the branch to this repo as `preview/<name>` to run the named-preview flow.
+
+## Build artifact is reused (no double builds)
+
+- `build-check` uploads the built Next.js site as an artifact named `nextjs-build-pr-<N>` (where `<N>` is the PR number).
+- `preview-deploy` downloads the same `nextjs-build-pr-<N>` artifact instead of rebuilding. There is exactly one `pnpm build` per PR push.
+- If `build-check` fails, `preview-deploy` does not run, so there is no attempt to deploy a broken build.
+
+## Quick reference
+
+| Flow            | Trigger                       | URL                                               | Comment marker             | Commit status           |
+| --------------- | ----------------------------- | ------------------------------------------------- | -------------------------- | ----------------------- |
+| PR preview      | Same-repo PR opened / updated | `https://pr-<N>.zmanuals.pages.dev/`              | `<!-- cf-preview-pr -->`   | `cloudflare/pr-preview` |
+| Named preview   | Push to `preview/*` branch    | `https://<branch>.zmanuals.pages.dev/`            | `<!-- cf-preview-branch -->` | —                       |
+| Forked PR       | PR from a fork                | _(no preview — secrets unavailable, by design)_   | —                          | —                       |

--- a/doc/src/data/category-nav.json
+++ b/doc/src/data/category-nav.json
@@ -7,6 +7,11 @@
         "position": 50
       },
       {
+        "docId": "inbox/pr-preview-url",
+        "title": "PR Preview URL (Cloudflare Pages)",
+        "position": 60
+      },
+      {
         "docId": "inbox/design-system",
         "title": "Design System",
         "position": 100

--- a/doc/src/data/doc-titles.json
+++ b/doc/src/data/doc-titles.json
@@ -2,5 +2,6 @@
   "inbox/bilingual-support": "Bilingual Support (JA / EN)",
   "inbox/design-system": "Design System",
   "inbox/index": "INBOX",
-  "inbox/pdf-to-nextjs-architecture": "PDF Processing to Next.js Architecture"
+  "inbox/pdf-to-nextjs-architecture": "PDF Processing to Next.js Architecture",
+  "inbox/pr-preview-url": "PR Preview URL (Cloudflare Pages)"
 }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/takazudomodular-manuals/issues/104

---

## Summary

- Auto-deploys a Cloudflare Pages preview for every same-repo PR using a deterministic URL pattern: `https://pr-<N>.zmanuals.pages.dev/manuals/oxi-one-mk2/`
- Extends `.github/workflows/pr-quality-checks.yml` with a new `preview-deploy` job that reuses the existing build artifact — no double build
- Posts/updates an in-place PR comment (marker `<!-- cf-preview-pr -->`) with the preview URL and sets a `cloudflare/pr-preview` commit status on every PR head
- Skips forked PRs cleanly (no secrets exposure); leaves the existing `preview/*` branch flow and `e2e-smoke-tests` gate unchanged
- Self-validated: this PR itself deployed successfully at `https://pr-108.zmanuals.pages.dev`

## Changes

### `.github/workflows/pr-quality-checks.yml`

- **`build-check`**: removed `if: startsWith(github.head_ref, 'preview/')` from the `Upload build artifacts (for e2e tests)` step so the artifact is uploaded for every PR (the name remains `nextjs-build-pr-${{ github.event.pull_request.number }}`, retention 1 day).
- **`e2e-smoke-tests`**: unchanged — still gated on `preview/*` head branches only.
- **New `preview-deploy` job**:
    - `needs: build-check`
    - `if: github.event.pull_request.head.repo.full_name == github.repository` — skips forked PRs
    - `timeout-minutes: 20`
    - `permissions: contents: read, pull-requests: write, deployments: write, statuses: write`
    - Steps: `checkout@v6` → `download-artifact@v6` (path `out`) → `./.github/actions/deploy-cloudflare` (id `deploy`, branch `pr-<N>`, commit-hash = PR head SHA) → `Log deploy URL` (proves output wiring) → `github-script` createDeployment + createDeploymentStatus → `github-script` upsert PR comment → `github-script` set commit status (`if: always()` so failed deploys still post a failure status)
    - All `${{ }}` values passed via `env:` blocks — never inlined into JS
    - Comment marker: `<!-- cf-preview-pr -->` (distinct from `<!-- cf-preview-branch -->` used by `preview-deploy.yml`)
    - No emoji in comment body (project convention)
    - Action SHAs reuse pins already present in this file — no new SHAs introduced

### Docs

- `CLAUDE.md`: added a PR preview URL bullet under the Deployed Website section
- `README.md`: added the PR preview URL to the deploy URL list
- `doc/docs/inbox/pr-preview-url.md`: new Docusaurus page documenting both preview flows (auto PR vs manual `preview/*`), their markers, the forked-PR caveat, and the artifact-reuse detail
- `doc/src/data/{category-nav,doc-titles}.json`: regenerated by `pnpm doc:build`

## Sub-issues (all closed)

- [x] #105 — Add preview-deploy job to pr-quality-checks.yml
- [x] #106 — Post/update PR comment with preview URL + commit status
- [x] #107 — Document PR preview URL pattern

## Test Plan

- [x] `pnpm check` passes on the merged base (typecheck + lint + format)
- [x] `pnpm doc:build` passes
- [x] CI on this PR: `Code Quality Checks`, `Build Check`, `Preview Deploy (Cloudflare Pages)`, `cloudflare/pr-preview` all green; `E2E Smoke Tests` correctly skipped (not a `preview/*` branch)
- [x] `/gcoc-review` against `main`: no findings (log at `~/cclogs/zmanuals/20260423_234330-gcoc-review.md`)
- [x] Feature end-to-end verified on this PR itself — preview URL deployed at `https://pr-108.zmanuals.pages.dev`, comment posted, commit status set
- [ ] On merge: `main-deploy.yml` triggers the production deploy (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)