### PR TITLE
chore(deps): update zfb to 0.1.0-next.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,8 @@
   },
   "dependencies": {
     "@netlify/classnames-template-literals": "^1.0.3",
-    "@takazudo/zfb": "0.1.0-next.23",
-    "@takazudo/zfb-runtime": "0.1.0-next.23",
+    "@takazudo/zfb": "0.1.0-next.24",
+    "@takazudo/zfb-runtime": "0.1.0-next.24",
     "minisearch": "^7.2.0",
     "preact": "^10.22.0",
     "preact-render-to-string": "^6.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       '@takazudo/zfb':
-        specifier: 0.1.0-next.23
-        version: 0.1.0-next.23
+        specifier: 0.1.0-next.24
+        version: 0.1.0-next.24
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.23
-        version: 0.1.0-next.23(@takazudo/zfb@0.1.0-next.23)
+        specifier: 0.1.0-next.24
+        version: 0.1.0-next.24(@takazudo/zfb@0.1.0-next.24)
       minisearch:
         specifier: ^7.2.0
         version: 7.2.0
@@ -3019,39 +3019,39 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.23':
-    resolution: {integrity: sha512-LhuWSXqkZJieUKKAHNBJX+svzaTjnrsNZwSV6T0XqZylFLfITd8Tx+IA79jr/w0Plb1HcP/CR2nuPMwJxyXoCw==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.24':
+    resolution: {integrity: sha512-fA4msmrMhmIor8VyuUdFFwEyRG4nwUp8PZuf4iDrawYYCrBNCVbOQmmz9FPtVV29uUVolegNdkssi8ANXpWMow==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.23':
-    resolution: {integrity: sha512-EGrWv5gc4o9PRRylAEX7bOSB0UjmfFfO8VihvvNjXpwww/jA75LkIzOUs8qujFavGP4w3lxpOWL/5Hie2F9LIA==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.24':
+    resolution: {integrity: sha512-CtVSggs40UYi/mLOcjqPs5gHcYEpSNNnaHnLN8PY/633EZ7/UUELYBsn4inwMt8dCU7mefwxaoKpezfKZ268mQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.23':
-    resolution: {integrity: sha512-/PaLs5YgUvXM7eZyGL+dl5Ced4j7RQpiTPDopfaYaog5CIl62SO1deqXLzvqSVltY/elskwN0ICL7XiRbyjyxg==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.24':
+    resolution: {integrity: sha512-LAMZtj4NwFd2iEiPtQty+aAJAAOQoUMoU3lhNqZJiZ0ecp+GdBipSPcfnoeObXg3kAPQgEGzOarDUb9SQi3AYQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.23':
-    resolution: {integrity: sha512-3uCL/4TD/7huaX+m3G2vlxVl63J9DJUaPf6PTWJJUu3VWlsZurxV5Xvopt5nV1ZgTABQKOFHAT4Hsg+YXcmb3Q==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.24':
+    resolution: {integrity: sha512-A3kZ+43jG8GJgeiDOl6jdr+wPvhbrN16mEfjWrJWVq7cVwaRHCw4Hc6Kj+jVBSByPQL/TYn7Mb93WBuRUkBagA==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.23':
-    resolution: {integrity: sha512-z/QXkiKAcaa0IfnRSOASIEphGYdBh7qQ0E6GskFDk9JxEmIHSFrl/bRaDErDapIkznapY1/qSx1hW48UYhzvag==}
+  '@takazudo/zfb-runtime@0.1.0-next.24':
+    resolution: {integrity: sha512-DzhHRkFiuorTUPqg2thOJD0yXK6hGnPy2e+1msn4vUPq4EhVaHP/s1U3ulG+Ivnl/9vaOoRPS7+JEJ5XP0KRgA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.23
+      '@takazudo/zfb': 0.1.0-next.24
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.23':
-    resolution: {integrity: sha512-5n3T1qKZTBHkKY6VQbkagbfm/KaM3gGFZgO59z8zQOk4V/fbxuws40qKj+q3VP/XxiqHsbdVhUQFu7RlKujEpQ==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.24':
+    resolution: {integrity: sha512-BSxeZAmwhqCP9ulSFV4kUByW4fAP52gS366AboX2LgeoVJ5cotPTc+Utymzq+s90oX5NV9RDm1og2BabXRHadw==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.23':
-    resolution: {integrity: sha512-0e29NdBxcO7LQUuqcbvisDhwrWOKXKA5tpqFKPkvhySzpKV5YiGGcGPUIEgWwEnktfz5/PxfzerUfuM7MnGJVQ==}
+  '@takazudo/zfb@0.1.0-next.24':
+    resolution: {integrity: sha512-qS+IjV6LAuZWVhbhTuqI4Jb0uR7de7liK9Li6ri5vLuegiVjdR+M+O+nzJ8E8+d4yAAf0Ztj0W9MUrSMhibShg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -11979,33 +11979,33 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.23':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.24':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.23':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.24':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.23':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.24':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.23':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.24':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.23(@takazudo/zfb@0.1.0-next.23)':
+  '@takazudo/zfb-runtime@0.1.0-next.24(@takazudo/zfb@0.1.0-next.24)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.23
+      '@takazudo/zfb': 0.1.0-next.24
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.23':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.24':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.23':
+  '@takazudo/zfb@0.1.0-next.24':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.23
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.23
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.23
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.23
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.23
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.24
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.24
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.24
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.24
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.24
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
- parent PR
    - https://github.com/Takazudo/takazudomodular-manuals/pull/138

---

## Summary

Bump `@takazudo/zfb` and `@takazudo/zfb-runtime` from `0.1.0-next.23` to `0.1.0-next.24`.

The only meaningful upstream change in `next.24` is a **backward-compatible type widening** in `@takazudo/zfb`'s `config.d.ts`: `admonitionsPreset` now accepts `boolean | AdmonitionsPresetOptions` (previously `FeatureToggle`), with new exported helper types (`AdmonitionDirectiveSpec`, `AdmonitionsPresetOptions`, `AdmonitionsPresetFeature`). There are **no dependency or peer-dependency changes**, and `@takazudo/zfb-runtime` is a version-only re-release (no code change).

This project does not use `admonitionsPreset`, so no config or source changes were required — the bump is limited to `package.json` + `pnpm-lock.yaml`.

## Changes
- `package.json`: `@takazudo/zfb` and `@takazudo/zfb-runtime` → `0.1.0-next.24`
- `pnpm-lock.yaml`: regenerated for the new versions

## Test Plan
- [x] `pnpm check` (typecheck + lint + format) — pass
- [x] `pnpm test:unit` (168 tests) — pass
- [x] `pnpm build` (zfb build → 1214 HTML files + Docusaurus) — pass
- [x] CI: Build Check + Code Quality Checks — pass