### PR TITLE
chore(deps): update zfb to 0.1.0-next.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,8 @@
   },
   "dependencies": {
     "@netlify/classnames-template-literals": "^1.0.3",
-    "@takazudo/zfb": "0.1.0-next.28",
-    "@takazudo/zfb-runtime": "0.1.0-next.28",
+    "@takazudo/zfb": "0.1.0-next.35",
+    "@takazudo/zfb-runtime": "0.1.0-next.35",
     "minisearch": "^7.2.0",
     "preact": "^10.22.0",
     "preact-render-to-string": "^6.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       '@takazudo/zfb':
-        specifier: 0.1.0-next.28
-        version: 0.1.0-next.28
+        specifier: 0.1.0-next.35
+        version: 0.1.0-next.35
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.28
-        version: 0.1.0-next.28(@takazudo/zfb@0.1.0-next.28)
+        specifier: 0.1.0-next.35
+        version: 0.1.0-next.35(@takazudo/zfb@0.1.0-next.35)
       minisearch:
         specifier: ^7.2.0
         version: 7.2.0
@@ -3019,39 +3019,39 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.28':
-    resolution: {integrity: sha512-YN+TPBTkWWeh6AkMvYCr5c1Q2/EC0ICoHTDZKAXIdQo6RUPiggn85iBbQFRwKLpsRRB3GwnVfm4ZkbNczLhklQ==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.35':
+    resolution: {integrity: sha512-zITxJqQx83JXJb3vCTkGx6IFHUUYvZWomitVY7wLPvn+A3GbVthhcnIDo9lsIOpAdZzyMBQbxl7fsOgL5lPseA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.28':
-    resolution: {integrity: sha512-BHEjau348S2uVCO74RHy3Dlmf3MvykqHKlkQj/j+3WRfBI6zITybR8NhyJuXM8lhijvbS4F9yjEogiiXQHMGGQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.35':
+    resolution: {integrity: sha512-v9/5AvcH4ehWd5gwojJTDJTo2dCf5JI2AIcJlUYIKZVJkLw4XMxhtzp8ZagfA5yzvfkqCfiBs7RM7ed+d9DKzQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.28':
-    resolution: {integrity: sha512-KeIDrIci9swLR9oh9pYZoeMm352QvGKU1Po0XmdUPhzfOJIl5P+GoaPN+u0+VYGw6S0O5Qsuxo6GuI5Im/WQ2A==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.35':
+    resolution: {integrity: sha512-cjiTbQd0uon8Q44jXGv2RWviwgkd8UU4yAjn7p+zOQBBLoNHIq55tDqjKmV47NCLmuChVTVubOlmYczFjU+bOg==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.28':
-    resolution: {integrity: sha512-qjkoFy/YxO+EExNHsgslX6fyzYZl2qt7OxU4GKcSh4vOiIRGjMlvRDkR/EkA0bbDNWae5Dj9YeG+p6uBoTCwYg==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.35':
+    resolution: {integrity: sha512-0ZpKY+vUmziaQfJThF0aA4Phl+EW5fxk1DBDt/TRs4X/J8Fv3G3sOj+2ljEI7t5iIkJoVjeeNxZKTL9sGAn8Dw==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.28':
-    resolution: {integrity: sha512-6Jh3n4CVYvtJWH4UhPyHvs64YSCTi5jWITAZ1hap8KFwsm+pGdzQPL77cP100cV+eiil/x7FC/3YwmDgpxXd4Q==}
+  '@takazudo/zfb-runtime@0.1.0-next.35':
+    resolution: {integrity: sha512-PA5Ti3UB2/izMLyFRXspD+ffrSCXMcG0OlHE4B9D8HpljvvdFyt0FI8u95L+kOlJFeSHG9bPw14c30cNLf0+Xw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.28
+      '@takazudo/zfb': 0.1.0-next.35
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.28':
-    resolution: {integrity: sha512-TfwCuBlBVLKkKV+ma1xh7IzqsK6AJmHZlG3LfaTDKFCpnbzxapFxdrf3FEQYbojYgREyF0Sza+ssnGdVlXx9JQ==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.35':
+    resolution: {integrity: sha512-0wjK34hsd8KZDVNIA0Cr071aaTYYoKzPkcbXwaHvHJGNW0YB2y+ARY67cUdKLj5A9jc2mXdSNr1Zt4Y1OE3pZQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.28':
-    resolution: {integrity: sha512-XSEH/nh0I6fIAFaBuKE/DQ87jPY+E01rVSzrIzTfFkzHmYVQa1BQml+rb+8BY2QgbluyGoB5rNRRfJki51dokw==}
+  '@takazudo/zfb@0.1.0-next.35':
+    resolution: {integrity: sha512-WREfJQmNHpiOH8O2wW7uN8EyQr3xdFyyERKhPaAG6idLLTo2lOcy5VTHZUXnllQ1sSUf8Cv4iLGQz2J5lybZzQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -11979,33 +11979,33 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.28':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.28':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.28':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.28':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.28(@takazudo/zfb@0.1.0-next.28)':
+  '@takazudo/zfb-runtime@0.1.0-next.35(@takazudo/zfb@0.1.0-next.35)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.28
+      '@takazudo/zfb': 0.1.0-next.35
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.28':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.28':
+  '@takazudo/zfb@0.1.0-next.35':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.28
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.28
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.28
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.28
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.28
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.35
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.35
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.35
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.35
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.35
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary

Bump `@takazudo/zfb` and `@takazudo/zfb-runtime` from `0.1.0-next.28` to `0.1.0-next.35` (current npm latest). Routine framework dependency update following the established cadence on `base/zfb-migration`.

## Changes

- `package.json`: `@takazudo/zfb` and `@takazudo/zfb-runtime` → `0.1.0-next.35`
- `pnpm-lock.yaml`: regenerated via `pnpm install`

## What changed upstream (next.29 → next.35)

Internal build/dev improvements and opt-in features only — **no breaking API changes**, no app code changes required:

- Islands code-splitting; `zfb build` now wipes the outdir at build start (verified our `public/`-written search index still lands in `dist/`)
- Optional-catchall `[[...slug]]` routes; route-ordering fixes
- Security: `@takazudo/zfb-runtime` hono floor raised to `^4.12.23`
- Opt-in: hierarchical heading IDs, configurable `readingTime` WPM
- Bin wrapper signal-forwarding; `resolve_links` bare `#anchor`/`?query` fix

## Test Plan

- ✅ `pnpm check` (typecheck + lint + format)
- ✅ `pnpm build` — search index (53 files), hashed assets (`dist/manuals/assets/`), and base-path asset references all correct in `dist/`
- ✅ `/codex-review` — no actionable regressions