### PR TITLE
Add Amazon-style hover-zoom magnifier to the manual page viewer

### DIFF
--- a/components/zfb/__tests__/zoom.test.ts
+++ b/components/zfb/__tests__/zoom.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for components/zfb/zoom.ts — pure hover-zoom helpers.
+ *
+ * Mirrors lang.test.ts: covers persistence (localStorage round-trip + default
+ * fallback) and the clamp helper used by the magnifier math. The hover
+ * interaction itself (lens/panel geometry) requires the island + a real
+ * pointer and is validated by e2e/UI verification.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ZOOM_ENABLED,
+  ZOOM_MAX_FACTOR,
+  ZOOM_MIN_FACTOR,
+  ZOOM_STORAGE_KEY,
+  clamp,
+  readPersistedZoom,
+  writeZoomToStorage,
+} from '../zoom';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('readPersistedZoom()', () => {
+  it('returns false (DEFAULT_ZOOM_ENABLED) when nothing is stored', () => {
+    expect(readPersistedZoom()).toBe(DEFAULT_ZOOM_ENABLED);
+    expect(readPersistedZoom()).toBe(false);
+  });
+
+  it('returns true only for the exact stored "1" flag', () => {
+    window.localStorage.setItem(ZOOM_STORAGE_KEY, '1');
+    expect(readPersistedZoom()).toBe(true);
+  });
+
+  it('treats "0" and any other value as disabled', () => {
+    window.localStorage.setItem(ZOOM_STORAGE_KEY, '0');
+    expect(readPersistedZoom()).toBe(false);
+    window.localStorage.setItem(ZOOM_STORAGE_KEY, 'yes');
+    expect(readPersistedZoom()).toBe(false);
+  });
+});
+
+describe('writeZoomToStorage()', () => {
+  it('persists the enabled flag as "1"/"0" and round-trips through readPersistedZoom', () => {
+    writeZoomToStorage(true);
+    expect(window.localStorage.getItem(ZOOM_STORAGE_KEY)).toBe('1');
+    expect(readPersistedZoom()).toBe(true);
+
+    writeZoomToStorage(false);
+    expect(window.localStorage.getItem(ZOOM_STORAGE_KEY)).toBe('0');
+    expect(readPersistedZoom()).toBe(false);
+  });
+});
+
+describe('clamp()', () => {
+  it('returns the value when within range', () => {
+    expect(clamp(3, ZOOM_MIN_FACTOR, ZOOM_MAX_FACTOR)).toBe(3);
+  });
+
+  it('clamps below the minimum and above the maximum', () => {
+    expect(clamp(1, ZOOM_MIN_FACTOR, ZOOM_MAX_FACTOR)).toBe(ZOOM_MIN_FACTOR);
+    expect(clamp(99, ZOOM_MIN_FACTOR, ZOOM_MAX_FACTOR)).toBe(ZOOM_MAX_FACTOR);
+  });
+
+  it('returns the bounds at the edges', () => {
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+});

--- a/components/zfb/header-utility-bar.tsx
+++ b/components/zfb/header-utility-bar.tsx
@@ -14,6 +14,9 @@ export interface HeaderUtilityBarProps {
   onToggleViewMode: () => void;
   onToggleSidebar: () => void;
   onOpenThumbsModal: () => void;
+  /** Hover-zoom enabled flag (page mode only). */
+  zoomEnabled: boolean;
+  onToggleZoom: () => void;
   lang: Lang;
   setLang: (next: Lang) => void;
   availableLangs: readonly Lang[];
@@ -43,36 +46,57 @@ const utilityButtonWrapperStyles = ctl(`
   relative group
 `);
 
-const utilityButtonStyles = ctl(`
+const utilityButtonBaseStyles = ctl(`
   w-[32px] h-[32px]
   flex items-center justify-center
-  bg-zd-gray3 hover:bg-zd-gray4
   border border-zd-gray4
   text-zd-white text-sm
   rounded-sm
   transition-colors
   cursor-pointer
-  active:bg-zd-gray5
 `);
+
+// Resting toggle: gray3 base, lighten on hover, darken on press.
+const utilityButtonInactiveStyles = ctl(`
+  bg-zd-gray3 hover:bg-zd-gray4 active:bg-zd-gray5
+`);
+
+// Engaged toggle (aria-pressed): persistent darkened fill, matching the
+// LanguageToggle's active-segment treatment (bg-zd-gray5).
+const utilityButtonActiveStyles = ctl(`
+  bg-zd-gray5 hover:bg-zd-gray4
+`);
+
+function cx(...classes: Array<string | false | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
 
 function TooltipButton({
   onClick,
   ariaLabel,
   tooltip,
+  active,
   children,
 }: {
   onClick: () => void;
   ariaLabel: string;
   tooltip: string;
+  /** When defined, the button is a toggle: reflected via aria-pressed + fill. */
+  active?: boolean;
   children: ComponentChildren;
 }) {
+  const isToggle = active !== undefined;
   return (
     <div className={utilityButtonWrapperStyles}>
       <button
         type="button"
-        className={utilityButtonStyles}
+        className={cx(
+          utilityButtonBaseStyles,
+          active ? utilityButtonActiveStyles : utilityButtonInactiveStyles,
+        )}
         onClick={onClick}
         aria-label={ariaLabel}
+        aria-pressed={isToggle ? active : undefined}
       >
         {children}
       </button>
@@ -90,6 +114,8 @@ export function HeaderUtilityBar({
   onToggleViewMode,
   onToggleSidebar,
   onOpenThumbsModal,
+  zoomEnabled,
+  onToggleZoom,
   lang,
   setLang,
   availableLangs,
@@ -107,6 +133,18 @@ export function HeaderUtilityBar({
           >
             {viewMode === 'page' ? '\u{1F4C4}' : '\u{1F4DC}'}
           </TooltipButton>
+          {/* Hover-zoom is a page-mode-only interaction (left image / right text);
+              hide the toggle in scroll mode rather than offer a no-op button. */}
+          {viewMode === 'page' && (
+            <TooltipButton
+              onClick={onToggleZoom}
+              ariaLabel={zoomEnabled ? 'Disable hover zoom' : 'Enable hover zoom'}
+              tooltip={zoomEnabled ? '拡大表示オフ' : '拡大表示オン'}
+              active={zoomEnabled}
+            >
+              {'\u{1F50D}'}
+            </TooltipButton>
+          )}
           <TooltipButton onClick={onToggleSidebar} ariaLabel="Toggle sidebar" tooltip="サムネイル">
             {'☰'}
           </TooltipButton>

--- a/components/zfb/manual-app.tsx
+++ b/components/zfb/manual-app.tsx
@@ -7,6 +7,7 @@ import type { ManualPage } from '@/lib/types/manual';
 import type { Lang } from './lang';
 import type { ManualAppProps, ViewMode } from './manual-app-types';
 import { useLang } from './use-lang';
+import { useZoom } from './use-zoom';
 import { getManualBasePath, getPagePath } from './routing';
 import { HeaderUtilityBar } from './header-utility-bar';
 import { PageViewer } from './page-viewer';
@@ -80,6 +81,10 @@ export default function ManualApp({
   const [viewMode, setViewMode] = useState<ViewMode>('page');
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [thumbsModalOpen, setThumbsModalOpen] = useState(false);
+
+  // Hover-zoom (Amazon-style page magnifier) — page mode only. Persisted, but
+  // SSR-safe: defaults to off until the post-mount effect reads localStorage.
+  const [zoomEnabled, toggleZoom] = useZoom();
 
   const toggleViewMode = useCallback(() => {
     setViewMode((prev) => (prev === 'page' ? 'scroll' : 'page'));
@@ -248,6 +253,7 @@ export default function ManualApp({
           onNavigate={navigateToPage}
           onNavigateHome={navigateHome}
           navDisabled={navDisabled}
+          zoomEnabled={zoomEnabled}
         />
       )
     ) : null;
@@ -275,6 +281,8 @@ export default function ManualApp({
         onToggleViewMode={toggleViewMode}
         onToggleSidebar={toggleSidebar}
         onOpenThumbsModal={openThumbsModal}
+        zoomEnabled={zoomEnabled}
+        onToggleZoom={toggleZoom}
         lang={lang}
         setLang={setLang}
         availableLangs={availableLangs}

--- a/components/zfb/page-viewer.tsx
+++ b/components/zfb/page-viewer.tsx
@@ -3,6 +3,7 @@ import ctl from './ctl';
 import type { ManualPage } from '@/lib/types/manual';
 import type { Lang } from './lang';
 import { withBasePath } from './routing';
+import { clamp, ZOOM_MIN_FACTOR, ZOOM_MAX_FACTOR } from './zoom';
 import { ProseContent } from './prose-content';
 import { PageNavigation } from './page-navigation';
 import { KeyboardNavigation } from './keyboard-navigation';
@@ -34,7 +35,12 @@ interface PageViewerProps {
   onNavigateHome: () => void;
   /** When true (fetch failed), in-manual nav is disabled. */
   navDisabled?: boolean;
+  /** When true, hovering the page image shows the Amazon-style magnifier. */
+  zoomEnabled?: boolean;
 }
+
+/** Class toggled on the lens/panel to reveal them while hovering. */
+const ZOOM_ACTIVE_CLASS = 'is-active';
 
 export function PageViewer({
   page,
@@ -45,15 +51,128 @@ export function PageViewer({
   onNavigate,
   onNavigateHome,
   navDisabled = false,
+  zoomEnabled = false,
 }: PageViewerProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const prevPageRef = useRef({ currentPage, manualId });
   const imgRef = useRef<HTMLImageElement>(null);
 
+  // ── Hover-zoom (Amazon-style magnifier) ──────────────────────────────────
+  // Lens overlays the source image; the panel fills the translation column and
+  // shows the magnified region. Both are `position: fixed` (positioned in
+  // viewport coords straight from getBoundingClientRect — no scroll-offset math)
+  // and `pointer-events: none` (so the mouse keeps hitting the image, not them).
+  const contentColRef = useRef<HTMLDivElement>(null);
+  const lensRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  // rAF handle — coalesces the high-frequency mousemove into one paint/frame.
+  const zoomRafRef = useRef<number | null>(null);
+  const lastPointerRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+
   const handleImageLoad = useCallback(() => {
     setIsLoading(false);
   }, []);
+
+  // Compute and apply the lens + panel geometry for a given viewport pointer.
+  // Geometry is fed in via CSS custom properties (set imperatively here, never
+  // re-rendering); the visual rules live in `.zoom-lens`/`.zoom-panel` in
+  // global.css. This is the standard mechanism for per-frame, data-driven
+  // positioning that Tailwind utility classes cannot express.
+  const applyZoom = useCallback((clientX: number, clientY: number) => {
+    const img = imgRef.current;
+    const lens = lensRef.current;
+    const panel = panelRef.current;
+    const col = contentColRef.current;
+    if (!img || !lens || !panel || !col) return;
+    const naturalWidth = img.naturalWidth;
+    if (naturalWidth === 0) return; // image not loaded yet
+
+    const imgRect = img.getBoundingClientRect();
+    const colRect = col.getBoundingClientRect();
+    if (imgRect.width === 0 || colRect.width === 0 || colRect.height === 0) return;
+
+    // Magnification = native-to-displayed ratio (sharpest), clamped to a sane
+    // reading range so the lens is neither huge (too little zoom) nor tiny.
+    const factor = clamp(naturalWidth / imgRect.width, ZOOM_MIN_FACTOR, ZOOM_MAX_FACTOR);
+
+    // Lens = region of the *displayed* image that maps onto the whole panel.
+    // Its aspect ratio follows the panel's; never let it exceed the image.
+    const lensW = Math.min(colRect.width / factor, imgRect.width);
+    const lensH = Math.min(colRect.height / factor, imgRect.height);
+
+    // Center the lens on the cursor, clamped so it stays within the image.
+    const cursorX = clamp(clientX - imgRect.left, 0, imgRect.width);
+    const cursorY = clamp(clientY - imgRect.top, 0, imgRect.height);
+    const lensX = clamp(cursorX - lensW / 2, 0, imgRect.width - lensW);
+    const lensY = clamp(cursorY - lensH / 2, 0, imgRect.height - lensH);
+
+    lens.style.setProperty('--zoom-lens-left', `${imgRect.left + lensX}px`);
+    lens.style.setProperty('--zoom-lens-top', `${imgRect.top + lensY}px`);
+    lens.style.setProperty('--zoom-lens-width', `${lensW}px`);
+    lens.style.setProperty('--zoom-lens-height', `${lensH}px`);
+
+    panel.style.setProperty('--zoom-panel-left', `${colRect.left}px`);
+    panel.style.setProperty('--zoom-panel-top', `${colRect.top}px`);
+    panel.style.setProperty('--zoom-panel-width', `${colRect.width}px`);
+    panel.style.setProperty('--zoom-panel-height', `${colRect.height}px`);
+    panel.style.setProperty(
+      '--zoom-bg-size',
+      `${imgRect.width * factor}px ${imgRect.height * factor}px`,
+    );
+    panel.style.setProperty('--zoom-bg-pos', `${-lensX * factor}px ${-lensY * factor}px`);
+  }, []);
+
+  const deactivateZoom = useCallback(() => {
+    if (zoomRafRef.current !== null) {
+      cancelAnimationFrame(zoomRafRef.current);
+      zoomRafRef.current = null;
+    }
+    lensRef.current?.classList.remove(ZOOM_ACTIVE_CLASS);
+    panelRef.current?.classList.remove(ZOOM_ACTIVE_CLASS);
+  }, []);
+
+  const activateZoom = useCallback(() => {
+    const panel = panelRef.current;
+    if (panel && page.image) {
+      // Same asset as the <img> src; set once per activation.
+      panel.style.setProperty('--zoom-image', `url("${withBasePath(page.image)}")`);
+    }
+    lensRef.current?.classList.add(ZOOM_ACTIVE_CLASS);
+    panelRef.current?.classList.add(ZOOM_ACTIVE_CLASS);
+  }, [page.image]);
+
+  const eligibleForZoom = useCallback(
+    () => zoomEnabled && !hasError && !!page.image && (imgRef.current?.naturalWidth ?? 0) > 0,
+    [zoomEnabled, hasError, page.image],
+  );
+
+  const handleZoomEnter = useCallback(
+    (e: MouseEvent) => {
+      if (!eligibleForZoom()) return;
+      activateZoom();
+      applyZoom(e.clientX, e.clientY);
+    },
+    [eligibleForZoom, activateZoom, applyZoom],
+  );
+
+  const handleZoomMove = useCallback(
+    (e: MouseEvent) => {
+      if (!eligibleForZoom()) return;
+      lastPointerRef.current = { x: e.clientX, y: e.clientY };
+      if (zoomRafRef.current !== null) return;
+      zoomRafRef.current = requestAnimationFrame(() => {
+        zoomRafRef.current = null;
+        activateZoom();
+        applyZoom(lastPointerRef.current.x, lastPointerRef.current.y);
+      });
+    },
+    [eligibleForZoom, activateZoom, applyZoom],
+  );
+
+  const handleZoomLeave = useCallback(() => {
+    deactivateZoom();
+  }, [deactivateZoom]);
 
   // Check if image is already loaded on mount (handles cached images).
   // useLayoutEffect runs before paint, preventing flicker.
@@ -72,6 +191,27 @@ export function PageViewer({
     }
     prevPageRef.current = { currentPage, manualId };
   }, [currentPage, manualId]);
+
+  // Disabling zoom mid-hover must hide the UI immediately.
+  useEffect(() => {
+    if (!zoomEnabled) deactivateZoom();
+  }, [zoomEnabled, deactivateZoom]);
+
+  // A new page swaps the image: drop any active zoom and the stale background
+  // (re-set lazily on the next hover from the new page's src).
+  useEffect(() => {
+    deactivateZoom();
+    panelRef.current?.style.removeProperty('--zoom-image');
+  }, [currentPage, manualId, deactivateZoom]);
+
+  // Cancel a pending frame on unmount so the rAF callback never touches a
+  // torn-down element.
+  useEffect(
+    () => () => {
+      if (zoomRafRef.current !== null) cancelAnimationFrame(zoomRafRef.current);
+    },
+    [],
+  );
 
   return (
     <>
@@ -119,6 +259,9 @@ export function PageViewer({
                     setIsLoading(false);
                     setHasError(true);
                   }}
+                  onMouseEnter={zoomEnabled ? handleZoomEnter : undefined}
+                  onMouseMove={zoomEnabled ? handleZoomMove : undefined}
+                  onMouseLeave={zoomEnabled ? handleZoomLeave : undefined}
                   data-testid="page-image"
                 />
               </>
@@ -127,7 +270,11 @@ export function PageViewer({
         </div>
 
         {/* Right Column: Translation */}
-        <div className={viewerContentColumnStyles} data-testid="translation-column">
+        <div
+          ref={contentColRef}
+          className={viewerContentColumnStyles}
+          data-testid="translation-column"
+        >
           <div className={viewerNavigationWrapperStyles} data-testid="page-navigation-wrapper">
             <PageNavigation
               currentPage={currentPage}
@@ -140,6 +287,16 @@ export function PageViewer({
           <ProseContent page={page} lang={lang} />
         </div>
       </div>
+
+      {/* Hover-zoom overlays. Mounted whenever the feature is on (so the refs
+          exist before the first hover) but hidden until `.is-active` is toggled
+          on mouseenter. Both are fixed + pointer-events:none — see global.css. */}
+      {zoomEnabled && page.image && !hasError && (
+        <>
+          <div ref={lensRef} className="zoom-lens" aria-hidden="true" data-testid="zoom-lens" />
+          <div ref={panelRef} className="zoom-panel" aria-hidden="true" data-testid="zoom-panel" />
+        </>
+      )}
     </>
   );
 }

--- a/components/zfb/use-zoom.ts
+++ b/components/zfb/use-zoom.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import { DEFAULT_ZOOM_ENABLED, readPersistedZoom, writeZoomToStorage } from './zoom';
+
+/**
+ * Shared zoom-enabled state hook owned by the mega-island (ManualApp).
+ *
+ * SSR-safe: state initializes to DEFAULT_ZOOM_ENABLED (false) on first render so
+ * SSR and hydration always agree. The real persisted preference is read from
+ * localStorage in a useEffect, avoiding hydration mismatches.
+ *
+ * Returns [enabled, toggle] — `toggle` flips the flag and persists it.
+ */
+export function useZoom(): [boolean, () => void] {
+  const [enabled, setEnabled] = useState<boolean>(DEFAULT_ZOOM_ENABLED);
+
+  useEffect(() => {
+    const persisted = readPersistedZoom();
+    if (persisted !== DEFAULT_ZOOM_ENABLED) {
+      setEnabled(persisted);
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setEnabled((prev) => {
+      const next = !prev;
+      writeZoomToStorage(next);
+      return next;
+    });
+  }, []);
+
+  return [enabled, toggle];
+}

--- a/components/zfb/zoom.ts
+++ b/components/zfb/zoom.ts
@@ -1,0 +1,52 @@
+// Hover-zoom (Amazon-style page magnifier) constants and persistence helpers,
+// shared across the zfb mega-island. Mirrors lang.ts: the mega-island
+// (manual-app.tsx) owns the enabled flag as plain useState and threads it down
+// as props; persistence is localStorage-only (no URL param — the zoom toggle is
+// a viewing preference, not a shareable view state like ?lang=).
+
+/**
+ * localStorage key for persisting the zoom-enabled preference. Namespaced under
+ * `zmanuals:` to match the existing `zmanuals:lang` key and avoid collisions
+ * with other takazudomodular apps on the same origin.
+ */
+export const ZOOM_STORAGE_KEY = 'zmanuals:zoom';
+
+/** The feature ships off — the user opts in via the header toggle. */
+export const DEFAULT_ZOOM_ENABLED = false;
+
+/**
+ * Magnification bounds. The effective zoom factor is the source image's
+ * natural-to-displayed width ratio (so the panel shows native pixels — sharpest
+ * for reading scanned manual text), clamped into this range so the lens is
+ * neither uselessly large (too little zoom) nor impossibly tiny (too much).
+ */
+export const ZOOM_MIN_FACTOR = 2;
+export const ZOOM_MAX_FACTOR = 4;
+
+/**
+ * Read the persisted zoom preference. Only safe to call client-side (inside an
+ * effect) — guards against `window`/`localStorage` being unavailable during SSR.
+ */
+export function readPersistedZoom(): boolean {
+  if (typeof window === 'undefined') return DEFAULT_ZOOM_ENABLED;
+  try {
+    return window.localStorage.getItem(ZOOM_STORAGE_KEY) === '1';
+  } catch {
+    // Private-mode / access-denied: fall through to default.
+    return DEFAULT_ZOOM_ENABLED;
+  }
+}
+
+export function writeZoomToStorage(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(ZOOM_STORAGE_KEY, enabled ? '1' : '0');
+  } catch {
+    // Quota exceeded / private mode: persistence is best-effort.
+  }
+}
+
+/** Clamp a number into the inclusive [min, max] range. */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -688,3 +688,50 @@
     /* Reserved for optional future animations. v1 skips motion entirely. */
   }
 }
+
+/* ══════════════════════════════════════════════════════════════════════
+   Manual Page Hover-Zoom (Amazon-style magnifier)
+   Geometry (position/size/background) is supplied per-frame as CSS custom
+   properties set imperatively from page-viewer.tsx; the static look lives
+   here. Both elements are `position: fixed` (placed in viewport coords from
+   getBoundingClientRect) and `pointer-events: none` (the mouse must keep
+   hitting the source image). Hidden until JS adds `.is-active` on hover.
+   ══════════════════════════════════════════════════════════════════════ */
+
+.zoom-lens,
+.zoom-panel {
+  display: none;
+  position: fixed;
+  pointer-events: none;
+  z-index: 30;
+}
+
+.zoom-lens.is-active,
+.zoom-panel.is-active {
+  display: block;
+}
+
+/* Translucent box on the source image marking the magnified region. */
+.zoom-lens {
+  left: var(--zoom-lens-left, 0);
+  top: var(--zoom-lens-top, 0);
+  width: var(--zoom-lens-width, 0);
+  height: var(--zoom-lens-height, 0);
+  background: rgb(255 255 255 / 0.28);
+  border: 1px solid var(--zd-color-white);
+}
+
+/* Magnified view filling the translation column. */
+.zoom-panel {
+  left: var(--zoom-panel-left, 0);
+  top: var(--zoom-panel-top, 0);
+  width: var(--zoom-panel-width, 0);
+  height: var(--zoom-panel-height, 0);
+  background-color: var(--zd-color-white);
+  background-image: var(--zoom-image);
+  background-repeat: no-repeat;
+  background-size: var(--zoom-bg-size);
+  background-position: var(--zoom-bg-pos);
+  border: 1px solid var(--zd-color-gray4);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 0.45);
+}


### PR DESCRIPTION
- parent PR
    - https://github.com/Takazudo/takazudomodular-manuals/pull/138

---

## Summary

Adds an Amazon-product-detail-page-style hover magnifier to the manual page viewer (page mode). A new header toggle (🔍) enables/disables the feature and persists the choice. When enabled, hovering the left-side page image shows a lens that follows the cursor over the source image while a magnified panel fills the **entire** right-side translation column; moving the cursor pans the magnified region, and leaving the image (or disabling the toggle) hides the zoom UI. Default is **off**.

## Changes

- **`components/zfb/zoom.ts`** (new): `zmanuals:zoom` localStorage persistence (`readPersistedZoom`/`writeZoomToStorage`), `clamp`, and magnification bounds (`ZOOM_MIN_FACTOR=2`, `ZOOM_MAX_FACTOR=4`).
- **`components/zfb/use-zoom.ts`** (new): SSR-safe `useZoom()` hook (`[enabled, toggle]`), mirroring `use-lang.ts` — defaults off, reads persisted value post-mount.
- **`components/zfb/header-utility-bar.tsx`**: new pressed-state toggle button (`aria-pressed`), gated to `isDetailPage && viewMode === 'page'` (hidden in scroll mode rather than a no-op). Refactored the button styles into base + active/inactive variants.
- **`components/zfb/page-viewer.tsx`**: the magnifier. rAF-throttled `mousemove`; lens + panel geometry fed via CSS custom properties (no per-frame re-render); `position: fixed` + `pointer-events: none`. Magnification = native/displayed ratio clamped to [2, 4]; lens clamped within the image. Resets on disable / page change / unmount.
- **`styles/global.css`**: `.zoom-lens` / `.zoom-panel` static styles (custom-class precedent, like `.page-image-loader`), revealed via a JS-toggled `.is-active` class.
- **`components/zfb/manual-app.tsx`**: threads `zoomEnabled` / `toggleZoom` from the mega-island into the header bar and page viewer.
- **`components/zfb/__tests__/zoom.test.ts`** (new): persistence round-trip + `clamp` unit coverage.

## Test Plan

- `pnpm check` (typecheck + lint + format): clean.
- `pnpm test:unit`: 175 passed (incl. new `zoom.test.ts`).
- **Real-browser verification** against the production build (`dist` on :8030) via Playwright — 13/13 checks: toggle present & `aria-pressed`; disabled = no panel; hover activates lens + panel; **panel exactly covers the translation column** (`{700,60,740,840}`); background-image is the page PNG; lens stays within the image; **panning** changes background-position and moves the lens; leaving hides; disabling stops it. Screenshots confirmed the Amazon-style look (lens box + magnified right column, panning between regions).