### PR TITLE
Handle recent issues #163–#166 (docs, CSP plan, scroll fix, CI guard)

### DIFF
--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -42,6 +42,28 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Guard against stale generated registry
+        run: |
+          echo "🔍 Checking lib/zfb-registry.generated.ts is in sync with public/*/data..."
+          # Regenerate from public/*/data, then normalize with the repo's own
+          # prettier before diffing. The raw generator output is babel-ts/
+          # node-version sensitive, so a naive byte diff goes flaky-red on the
+          # runner; running prettier (same version as the format check that already
+          # passes for the committed file) cancels formatting differences, leaving
+          # only real content drift to fail the step.
+          pnpm run gen:registry
+          pnpm exec prettier --write lib/zfb-registry.generated.ts
+          if ! git diff --quiet -- lib/zfb-registry.generated.ts; then
+            echo "::error file=lib/zfb-registry.generated.ts::Generated registry is stale. Run 'pnpm run gen:registry' and commit the result."
+            echo "❌ lib/zfb-registry.generated.ts is out of sync with public/*/data."
+            echo "   A manual was likely added/removed (or scripts/gen-registry.js changed) without regenerating."
+            echo "   Fix: run 'pnpm run gen:registry' locally and commit the updated file."
+            echo "--- drift (committed vs. freshly generated) ---"
+            git --no-pager diff -- lib/zfb-registry.generated.ts
+            exit 1
+          fi
+          echo "✅ Generated registry is in sync"
+
       - name: Run TypeScript type checking
         run: |
           echo "🔍 Running TypeScript type checking..."

--- a/README.md
+++ b/README.md
@@ -122,32 +122,17 @@ This runs the full pipeline:
 **Time estimate**: 15-30 minutes (depending on manual size)
 **Cost estimate**: $5-10 per 280-page manual (Claude Sonnet 4.5)
 
-### 4. Update Manual Registry
+### 4. Regenerate the Manual Registry
 
-Edit `lib/manual-registry.ts` to import the new manual's data:
+The viewer registry is **single-sourced via codegen** — there is no import list to hand-edit:
 
-```typescript
-// Add imports for new manual
-import newManualManifest from '@/public/new-manual-slug/data/manifest.json';
-import newManualPages from '@/public/new-manual-slug/data/pages-ja.json';
-
-// Add to registry
-const MANUAL_REGISTRY: Record<string, ManualRegistryEntry> = {
-  'oxi-one-mk2': {
-    // ... existing manual
-  },
-  'new-manual-slug': {
-    manifest: newManualManifest as unknown as ManualManifest,
-    pages: newManualPages as unknown as ManualPagesData,
-  },
-};
+```bash
+pnpm run gen:registry
 ```
 
-**Why explicit imports?**
+`scripts/gen-registry.js` scans `public/<slug>/data/` for every directory that has both `manifest.json` and `pages-ja.json`, and regenerates `lib/zfb-registry.generated.ts` — the static import list + `REGISTRY` map that `lib/zfb-registry.ts` re-exports through its public API. Because the new manual's files already exist under `public/` by this step, regenerating picks them up automatically.
 
-- Type safety with TypeScript
-- Build-time bundling (no runtime fetch)
-- Compatible with zfb static site generation
+**Never edit `lib/zfb-registry.generated.ts` by hand** — commit the regenerated file alongside the new manual's data. Regeneration is idempotent (re-running with no changes yields zero diff).
 
 ### 5. Build and Deploy
 
@@ -205,7 +190,7 @@ public/new-manual-slug/         # Output (committed to git)
 
 - ✅ `public/{slug}/data/` - Final JSON files
 - ✅ `public/{slug}/pages/` - Rendered images
-- ✅ `lib/manual-registry.ts` - Updated registry
+- ✅ `lib/zfb-registry.generated.ts` - Regenerated registry (via `pnpm run gen:registry`)
 - ❌ `manual-pdf/{slug}/` - Source PDFs (gitignored)
 - ❌ `public/{slug}/processing/` - Temp files (gitignored)
 
@@ -277,7 +262,8 @@ cd worktrees/issue-X-feature-name
 │   └── zfb/                    # zfb-specific islands and utilities
 ├── lib/                        # Utilities and data loading
 │   ├── manual-data.ts          # Data loading logic
-│   ├── manual-registry.ts      # Manual registry (update for new manuals)
+│   ├── zfb-registry.generated.ts  # Code-generated registry (run `pnpm run gen:registry`)
+│   ├── zfb-registry.ts         # Public API re-exporting the generated registry
 │   └── types/                  # TypeScript types
 ├── e2e/                        # Playwright e2e tests
 ├── public/                     # Static manual assets

--- a/components/zfb/manual-app.tsx
+++ b/components/zfb/manual-app.tsx
@@ -205,23 +205,30 @@ export default function ManualApp({
 
   // Keep the viewer in sync with browser back/forward. The browser has already
   // changed the URL (that's what popstate means), so we never touch history
-  // here — we mirror navigateToPage's view-mode branching to move the viewer:
-  //   - scroll mode: route through the gated smooth-jump (scrollToPage). The
-  //     observer then syncs currentPage + replaceState as the scroll settles,
-  //     same as every other scroll-mode jump. Without this the URL changes but
-  //     the viewport stays put (#165). setCurrentPage alone won't scroll because
-  //     the mount-snap is gated to mount + explicit jump only (#154).
-  //   - page mode: just update currentPage to re-render the page body.
+  // here. We always update currentPage first, then additionally smooth-scroll
+  // in scroll mode:
+  //   - currentPage is the source of truth for the page body (page mode) and
+  //     for ScrollViewer's initialPage. Setting it unconditionally is also the
+  //     fallback that survives the data-loading window: if a scroll-mode
+  //     popstate fires before ScrollViewer has mounted (JSON still loading),
+  //     scrollViewerRef is null and the jump below no-ops, but the updated
+  //     currentPage becomes ScrollViewer's initialPage so it snaps to the right
+  //     page on mount instead of the stale one (which would otherwise let the
+  //     observer replaceState the URL back, undoing the navigation).
+  //   - scroll mode (mounted): route through the gated smooth-jump
+  //     (scrollToPage). The observer then re-syncs currentPage + replaceState
+  //     as the scroll settles. Without this the URL changes but the viewport
+  //     stays put (#165); the snap effect alone won't move it because it's
+  //     gated to mount + explicit jump only (#154).
   useEffect(() => {
     const onPopState = () => {
       const match = window.location.pathname.match(/\/page\/(\d+)/);
       if (match) {
         const n = parseInt(match[1], 10);
         if (n >= 1 && n <= totalPages) {
+          setCurrentPage(n);
           if (viewMode === 'scroll') {
             scrollViewerRef.current?.scrollToPage(n);
-          } else {
-            setCurrentPage(n);
           }
         }
       }

--- a/components/zfb/manual-app.tsx
+++ b/components/zfb/manual-app.tsx
@@ -203,18 +203,32 @@ export default function ManualApp({
     [manualId],
   );
 
-  // Keep currentPage in sync with browser back/forward.
+  // Keep the viewer in sync with browser back/forward. The browser has already
+  // changed the URL (that's what popstate means), so we never touch history
+  // here — we mirror navigateToPage's view-mode branching to move the viewer:
+  //   - scroll mode: route through the gated smooth-jump (scrollToPage). The
+  //     observer then syncs currentPage + replaceState as the scroll settles,
+  //     same as every other scroll-mode jump. Without this the URL changes but
+  //     the viewport stays put (#165). setCurrentPage alone won't scroll because
+  //     the mount-snap is gated to mount + explicit jump only (#154).
+  //   - page mode: just update currentPage to re-render the page body.
   useEffect(() => {
     const onPopState = () => {
       const match = window.location.pathname.match(/\/page\/(\d+)/);
       if (match) {
         const n = parseInt(match[1], 10);
-        if (n >= 1 && n <= totalPages) setCurrentPage(n);
+        if (n >= 1 && n <= totalPages) {
+          if (viewMode === 'scroll') {
+            scrollViewerRef.current?.scrollToPage(n);
+          } else {
+            setCurrentPage(n);
+          }
+        }
       }
     };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
-  }, [totalPages]);
+  }, [totalPages, viewMode]);
 
   // Thumbnails always use the JA list (language-independent page numbers).
   const thumbPages = pagesJa;

--- a/doc/docs/inbox/csp-hardening-plan.md
+++ b/doc/docs/inbox/csp-hardening-plan.md
@@ -1,0 +1,69 @@
+---
+title: CSP Flip-to-Enforced Hardening Plan
+sidebar_position: 70
+---
+
+# CSP Flip-to-Enforced Hardening Plan
+
+## Why this document exists
+
+Cloudflare `_headers` files cannot contain comments. The flip-to-enforced plan that was documented in the commit message for `612cddf` (PR #156) would otherwise be completely undiscoverable from `public/_headers`. This document captures that plan so it is not lost.
+
+## Current header (Report-Only phase)
+
+`public/_headers` currently sets the following header on all routes (`/*`):
+
+```
+Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
+```
+
+During the Report-Only phase the live site is unaffected by the policy — violations appear in the browser console only. This is intentional: the site is proxied through `takazudomodular.com/manuals/*` via a Netlify redirect, so a misconfigured enforced CSP could silently break hydration on the proxied origin in ways that `pnpm serve` on `localhost:8030` does NOT exercise.
+
+## Flip-to-enforced criteria
+
+Switch `Content-Security-Policy-Report-Only` → `Content-Security-Policy` only after all three steps below have been completed:
+
+### Step 1 — Confirm zero violations on the PR-preview origin
+
+The PR preview URL (`https://pr-<N>.zmanuals.pages.dev/manuals/oxi-one-mk2/`) goes through the real Cloudflare Pages + Netlify proxy chain. Open the browser console on that origin and verify there are **zero CSP violation reports** for any legitimate scripts, styles, images, or fonts before proceeding.
+
+### Step 2 — Replace `script-src 'unsafe-inline'` with the SHA-256 hash
+
+The only inline script on the page is `LANG_BOOTSTRAP_SCRIPT`, defined in `layouts/default.tsx`:
+
+```ts
+const LANG_BOOTSTRAP_SCRIPT = `(function(){try{var l=localStorage.getItem('zmanuals:lang');if(l==='en')document.documentElement.setAttribute('data-lang','en');}catch(e){}})();`;
+```
+
+This string is a build-time constant and its content never changes, so its SHA-256 hash is stable. Compute it with:
+
+```bash
+printf '%s' "(function(){try{var l=localStorage.getItem('zmanuals:lang');if(l==='en')document.documentElement.setAttribute('data-lang','en');}catch(e){}})();" \
+  | openssl dgst -sha256 -binary | base64
+```
+
+Replace `'unsafe-inline'` in `script-src` with `'sha256-<computed-hash>'`. When a hash is present, browsers ignore `'unsafe-inline'`, so the swap is clean and requires no other changes.
+
+### Step 3 — Audit `style-src 'unsafe-inline'`
+
+`'unsafe-inline'` was kept permissive for the Report-Only phase. Before flipping to enforced, audit whether any inline `<style>` elements or `style=` attributes remain in the rendered HTML. The Tailwind stylesheet is an external `<link rel="stylesheet">`, so it does not require `'unsafe-inline'`. Drop the token if no inline styles are found.
+
+### Step 4 — Rename the header
+
+Rename the header in `public/_headers`:
+
+```diff
+-  Content-Security-Policy-Report-Only: default-src 'self'; ...
++  Content-Security-Policy: default-src 'self'; ...
+```
+
+This is the actual "flip to enforced" step. It is a live-site security change and requires human sign-off before merging.
+
+## Future options (not yet decided)
+
+Instead of console-only violation reporting, a **reporting endpoint** could be added to collect violations centrally. This would be configured via the `report-to` / `report-uri` directives and backed by either:
+
+- A lightweight Cloudflare Worker that forwards reports to a logging service, or
+- A third-party report collection service (e.g. [report-uri.com](https://report-uri.com))
+
+This is an infrastructure decision deferred for now. The console-only approach is sufficient for the current Report-Only observation phase.

--- a/scripts/README-PDF-PROCESSING.md
+++ b/scripts/README-PDF-PROCESSING.md
@@ -127,8 +127,11 @@ pnpm run pdf:manifest --slug oxi-coral
    pnpm run pdf:all --slug new-manual-slug
    ```
 
-4. **Update registry** (`lib/manual-registry.ts`):
-   Add explicit imports for the new manual's JSON files.
+4. **Regenerate the manual registry** (single source of truth — no hand-editing):
+   ```bash
+   pnpm run gen:registry
+   ```
+   This scans `public/<slug>/data/` and regenerates `lib/zfb-registry.generated.ts` (consumed by `lib/zfb-registry.ts`). Never edit the generated file by hand.
 
 See main README.md for complete workflow.
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/takazudomodular-manuals/issues/163
    - https://github.com/Takazudo/takazudomodular-manuals/issues/164
    - https://github.com/Takazudo/takazudomodular-manuals/issues/165
    - https://github.com/Takazudo/takazudomodular-manuals/issues/166
- parent PR
    - https://github.com/Takazudo/takazudomodular-manuals/pull/138

---

## Summary
Batch handling of 4 atomic open issues, each implemented in its own worktree/topic branch and merged into this base. Deep-reviewed (codex) with one P2 fix applied; #165 browser-verified.

| Issue | Change | Files |
|---|---|---|
| #163 | Fix stale `lib/manual-registry.ts` doc references → `gen:registry` single-source story | `README.md`, `scripts/README-PDF-PROCESSING.md` |
| #164 | Document the CSP flip-to-enforced plan (doc-only; `_headers` unchanged, no report endpoint) | `doc/docs/inbox/csp-hardening-plan.md` |
| #165 | Route scroll-mode browser Back/Forward (popstate) through `scrollToPage`; preserve target during data-load window | `components/zfb/manual-app.tsx` |
| #166 | CI guard against stale `lib/zfb-registry.generated.ts` via tolerant regen→prettier→diff | `.github/workflows/pr-quality-checks.yml` |

## Verification
- `pnpm check` (typecheck/lint/format), `pnpm test:unit` (175 passed), format:md:check — all green
- **#165 browser-verified** (disposable Opus + Playwright): scroll viewport tracks URL on Back/Forward (scrollTop 1756→878→0→878); page-mode nav + intra-scroll replaceState confirmed
- **#166 guard verified** on this very PR (Code Quality Checks passed) and locally (in-sync passes, drift fails)
- Deep review (codex): 1 P2 finding (scroll popstate target lost during data-load) — **fixed** in `7e9c5de`

## Notes
- Targets `base/zfb-migration` (parent PR #138), not `main`, per the migration branch architecture.
- Raised unrelated finding #177 (eslint doesn't ignore `__inbox/`).