### PR TITLE
fix(eslint): ignore __inbox/ to stop spurious local pnpm check failures (#177)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ export default [
       'doc/**',
       'scripts/**',
       'worktrees/**',
+      '__inbox/**',
     ],
   },
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/takazudomodular-manuals/issues/177
- parent PR
    - https://github.com/Takazudo/takazudomodular-manuals/pull/138

---

## Summary
Adds `'__inbox/**'` to the global `ignores` array in `eslint.config.js`, aligning the eslint flat config with `lint-staged` and the `format` script (both already exclude `__inbox/`).

Fixes #177: leftover temp files under the gitignored `__inbox/` (where the project tells contributors to put temp files, per root `CLAUDE.md`) were being linted by `eslint .`, causing intermittent local `pnpm check` failures unrelated to any change.

## Changes
- `eslint.config.js`: add `'__inbox/**'` to the global `ignores` array, next to `'worktrees/**'` (one line).

## Test Plan
- Dropped a deliberately lint-breaking temp file at `__inbox/verify-eslint-ignore.mjs` (`getComputedStyle` → `no-undef`).
- `npx eslint --no-ignore __inbox/verify-eslint-ignore.mjs` → **3 errors** (confirms the file genuinely trips eslint).
- `pnpm lint` (respecting the new ignore) → **exit 0** (the temp file is now ignored).
- Removed the temp file; only change in the diff is the one-line `eslint.config.js` edit.