### PR TITLE
fix(viewer): pin page-mode loading overlay to the visible pane + pure white bg (#180)

### DIFF
--- a/components/zfb/page-viewer.tsx
+++ b/components/zfb/page-viewer.tsx
@@ -9,6 +9,7 @@ import { PageNavigation } from './page-navigation';
 import { KeyboardNavigation } from './keyboard-navigation';
 import {
   viewerContainerStyles,
+  viewerImageColumnOuterStyles,
   viewerImageColumnStyles,
   viewerContentColumnStyles,
   viewerImageWrapperStyles,
@@ -224,31 +225,24 @@ export function PageViewer({
       />
       <div className={viewerContainerStyles}>
         {/* Left Column: PDF Image */}
-        <div className={viewerImageColumnStyles} data-testid="page-image-column">
-          <div className={viewerImageWrapperStyles} data-testid="page-image-wrapper">
-            {hasError ? (
-              <div className={loaderWrapperStyles} data-testid="page-image-error">
-                <div className="text-zd-red text-center">
-                  <p className="text-lg font-bold mb-vgap-xs">画像の読み込みに失敗しました</p>
-                  <p className="text-sm text-zd-gray6">ページ {currentPage}</p>
+        <div className={viewerImageColumnOuterStyles} data-testid="page-image-column">
+          <div className={viewerImageColumnStyles} data-testid="page-image-scroll">
+            <div className={viewerImageWrapperStyles} data-testid="page-image-wrapper">
+              {hasError ? (
+                <div className={loaderWrapperStyles} data-testid="page-image-error">
+                  <div className="text-zd-red text-center">
+                    <p className="text-lg font-bold mb-vgap-xs">画像の読み込みに失敗しました</p>
+                    <p className="text-sm text-zd-gray6">ページ {currentPage}</p>
+                  </div>
                 </div>
-              </div>
-            ) : !page.image ? (
-              <div className={loaderWrapperStyles} data-testid="page-image-missing">
-                <div className="text-zd-gray6 text-center">
-                  <p className="text-lg mb-vgap-xs">画像がありません</p>
-                  <p className="text-sm">ページ {currentPage}</p>
+              ) : !page.image ? (
+                <div className={loaderWrapperStyles} data-testid="page-image-missing">
+                  <div className="text-zd-gray6 text-center">
+                    <p className="text-lg mb-vgap-xs">画像がありません</p>
+                    <p className="text-sm">ページ {currentPage}</p>
+                  </div>
                 </div>
-              </div>
-            ) : (
-              <>
-                {/* Loading overlay - fades out when image loads */}
-                <div
-                  className={`absolute inset-0 bg-zd-white z-10 flex items-center justify-center transition-opacity duration-300 ${isLoading ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
-                  data-testid="page-image-overlay"
-                >
-                  <div className="page-image-loader" />
-                </div>
+              ) : (
                 <img
                   ref={imgRef}
                   src={withBasePath(page.image)}
@@ -264,9 +258,21 @@ export function PageViewer({
                   onMouseLeave={zoomEnabled ? handleZoomLeave : undefined}
                   data-testid="page-image"
                 />
-              </>
-            )}
+              )}
+            </div>
           </div>
+          {/* Loading overlay — sibling of the scroll container (not inside it) so it
+              covers the visible pane and is unaffected by scroll position (#180).
+              Fades out when the image loads. */}
+          {!hasError && page.image && (
+            <div
+              className={`absolute inset-0 bg-white z-10 flex items-center justify-center transition-opacity duration-300 ${isLoading ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+              aria-hidden="true"
+              data-testid="page-image-overlay"
+            >
+              <div className="page-image-loader" />
+            </div>
+          )}
         </div>
 
         {/* Right Column: Translation */}

--- a/components/zfb/viewer-layout-styles.ts
+++ b/components/zfb/viewer-layout-styles.ts
@@ -17,13 +17,26 @@ export const viewerContainerStyles = ctl(`
 `);
 
 /**
- * Image column for page mode (viewer-shell + page-viewer only).
+ * Outer positioning wrapper for the page-mode image column (viewer-shell +
+ * page-viewer only). Carries the flex-child role and anchors the loading
+ * overlay OUTSIDE the scroll container so the overlay covers the visible
+ * pane regardless of scroll position (#180).
+ */
+export const viewerImageColumnOuterStyles = ctl(`
+  relative
+  flex-1
+  min-h-0
+  min-w-0
+`);
+
+/**
+ * Image column for page mode (viewer-shell + page-viewer only); the scroll
+ * container nested inside viewerImageColumnOuterStyles.
  * scroll-viewer has a different imageColumn layout so it must NOT use this.
  */
 export const viewerImageColumnStyles = ctl(`
-  flex-1
+  h-full
   overflow-y-scroll
-  min-h-0
   flex flex-col items-center
   bg-zd-white
 `);

--- a/components/zfb/viewer-shell.tsx
+++ b/components/zfb/viewer-shell.tsx
@@ -3,6 +3,7 @@ import { withBasePath } from './routing';
 import { ProseContent } from './prose-content';
 import {
   viewerContainerStyles,
+  viewerImageColumnOuterStyles,
   viewerImageColumnStyles,
   viewerContentColumnStyles,
   viewerImageWrapperStyles,
@@ -30,21 +31,23 @@ export function ViewerShell({ page, pageNum, totalPages }: ViewerShellProps) {
   return (
     <div className={viewerContainerStyles} data-testid="viewer-shell-ssr">
       {/* Left Column: PDF Image */}
-      <div className={viewerImageColumnStyles} data-testid="page-image-column">
-        <div className={viewerImageWrapperStyles} data-testid="page-image-wrapper">
-          {page.image ? (
-            <img
-              src={withBasePath(page.image)}
-              alt={`Page ${pageNum}: ${page.title}`}
-              className="w-full h-auto"
-              data-testid="page-image"
-            />
-          ) : (
-            <div className="text-zd-gray6 text-center p-hgap-md" data-testid="page-image-missing">
-              <p className="text-lg mb-vgap-xs">画像がありません</p>
-              <p className="text-sm">ページ {pageNum}</p>
-            </div>
-          )}
+      <div className={viewerImageColumnOuterStyles} data-testid="page-image-column">
+        <div className={viewerImageColumnStyles} data-testid="page-image-scroll">
+          <div className={viewerImageWrapperStyles} data-testid="page-image-wrapper">
+            {page.image ? (
+              <img
+                src={withBasePath(page.image)}
+                alt={`Page ${pageNum}: ${page.title}`}
+                className="w-full h-auto"
+                data-testid="page-image"
+              />
+            ) : (
+              <div className="text-zd-gray6 text-center p-hgap-md" data-testid="page-image-missing">
+                <p className="text-lg mb-vgap-xs">画像がありません</p>
+                <p className="text-sm">ページ {pageNum}</p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/e2e/viewer-ui.spec.ts
+++ b/e2e/viewer-ui.spec.ts
@@ -209,6 +209,45 @@ test.describe('Viewer UI: View Mode Toggle', () => {
   });
 });
 
+test.describe('Viewer UI: Page-mode loading overlay (#180)', () => {
+  test('overlay covers the visible pane regardless of scroll and is pure white', async ({
+    page,
+  }) => {
+    await page.goto(PAGE_URL);
+
+    const column = page.getByTestId('page-image-column');
+    const overlay = page.getByTestId('page-image-overlay');
+    await expect(column).toBeVisible();
+    // The overlay only exists in the interactive viewer (not the SSR shell) —
+    // its presence means hydration + data fetch completed.
+    await expect(overlay).toBeAttached();
+
+    const scrollArea = page.getByTestId('page-image-scroll');
+    await expect(page.getByTestId('page-image')).toBeVisible();
+
+    // Scroll the left pane down (the bug: the overlay used to scroll away with it)
+    await scrollArea.evaluate((el) => {
+      el.scrollTop = 500;
+    });
+    const scrolled = await scrollArea.evaluate((el) => el.scrollTop);
+    expect(scrolled).toBeGreaterThan(0);
+
+    // Overlay must still cover exactly the visible column area
+    const columnBox = await column.boundingBox();
+    const overlayBox = await overlay.boundingBox();
+    expect(columnBox).not.toBeNull();
+    expect(overlayBox).not.toBeNull();
+    expect(overlayBox!.x).toBeCloseTo(columnBox!.x, 1);
+    expect(overlayBox!.y).toBeCloseTo(columnBox!.y, 1);
+    expect(overlayBox!.width).toBeCloseTo(columnBox!.width, 1);
+    expect(overlayBox!.height).toBeCloseTo(columnBox!.height, 1);
+
+    // Background is pure white (#fff), not the design-system off-white
+    const bg = await overlay.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).toBe('rgb(255, 255, 255)');
+  });
+});
+
 test.describe('Viewer UI: No Console Errors', () => {
   test('should not have console errors during UI interactions', async ({ page }) => {
     const consoleErrors: string[] = [];


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/takazudomodular-manuals/issues/180

---

## Summary

Fixes #180. In page mode, the image-loading overlay was absolutely positioned inside the image wrapper, which lives **inside** the scrollable left column — so when the pane was scrolled, the overlay scrolled away with the content and the underlying page image showed through at the bottom. The overlay background also used the design-system off-white (`bg-zd-white`, `rgb(214 211 209)`), which reads as beige against the white PDF page paper.

## Changes

- **`viewer-layout-styles.ts`** — split the page-mode image column into two layers:
  - new `viewerImageColumnOuterStyles` (`relative flex-1 min-h-0 min-w-0`): carries the flex-child role and anchors the overlay outside the scroll container
  - `viewerImageColumnStyles` is now the inner scroll container (`h-full overflow-y-scroll flex flex-col items-center bg-zd-white`)
- **`page-viewer.tsx`** — the loading overlay is hoisted out of the scrollable area to sibling position next to the scroll container (`absolute inset-0` on the relative outer wrapper), so it always covers exactly the visible pane regardless of scroll position. Overlay bg `bg-zd-white` → `bg-white` (pure `#fff`), `aria-hidden="true"` added (the spinner is purely visual)
- **`viewer-shell.tsx`** — mirrors the same outer + inner structure via the shared style constants so the post-fetch swap in `manual-app.tsx` stays visually seamless
- **`e2e/viewer-ui.spec.ts`** — new test: scrolls the left pane, asserts the overlay bounding box equals the visible column box, and asserts the computed bg is `rgb(255, 255, 255)`

Error/missing states stay inside the scroll container (they don't overflow). `scroll-viewer.tsx` is untouched (its per-page placeholder mechanism is separate).

## Test Plan

- [x] `pnpm check` (typecheck + lint + format) — changed files pass
- [x] `pnpm test:unit` — 175/175 pass
- [x] `pnpm build` — production build succeeds
- [x] `npx playwright test e2e/viewer-ui.spec.ts` against the production build — new overlay test passes (the one pre-existing sidebar-test failure is tracked separately in #185)
- [x] Codex review vs main — no actionable findings

## Related agent-found issues (pre-existing, out of scope)

#182 (stray `.playwright-cli` artifacts break local `pnpm check`), #183 (playwright webServer references nonexistent `zfb:build`), #184 (stale generated doc nav data), #185 (sidebar e2e test drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)