### PR TITLE
Fix e2e sidebar drift, drop CI artifact churn, enforce CSP

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -19,9 +19,17 @@ permissions:
   statuses: write
 
 jobs:
-  # Step 1: Build for production
-  build:
-    name: Build Production Site
+  # Single job: build + deploy in one runner.
+  #
+  # Previously this was a build job that uploaded an ~880 MB artifact and a
+  # separate deploy job that downloaded it. That artifact counted against the
+  # 2 GB Actions storage cap on every push to main. Merging the two jobs lets
+  # the deploy reuse the build output in-place (dist/) with nothing persisted to
+  # Actions storage. The build step still runs before the deploy step, so a
+  # broken build fails the job before anything is deployed — "build gates
+  # deploy" is preserved.
+  build-and-deploy:
+    name: Build and Deploy to Production
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -35,33 +43,6 @@ jobs:
         uses: ./.github/actions/build-zfb
         with:
           node-version: '22'
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
-        with:
-          name: zfb-build-production
-          path: dist/
-          include-hidden-files: true
-          retention-days: 1
-
-  # Step 2: Deploy to production
-  deploy:
-    name: Deploy to Production
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          lfs: false
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
-        with:
-          name: zfb-build-production
-          path: dist
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -199,7 +199,15 @@ jobs:
           echo "========================="
           echo "Build output verified"
 
+      # Only persist the ~880 MB build artifact where it is actually consumed:
+      # the e2e-smoke-tests job runs on preview/* branches ONLY. On every other
+      # PR the artifact would be uploaded, count against the 2 GB Actions storage
+      # cap, and never be downloaded. preview-deploy now builds the site itself
+      # instead of consuming this artifact, so this upload is preview/* only.
+      # This workflow only triggers on pull_request, so github.head_ref is always
+      # defined here (no push-event guard needed).
       - name: Upload build artifacts (for e2e tests)
+        if: startsWith(github.head_ref, 'preview/')
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: zfb-build-pr-${{ github.event.pull_request.number }}
@@ -321,11 +329,19 @@ jobs:
             }
 
   # Job 4: Preview Deploy (Cloudflare Pages) for same-repo PRs
+  #
+  # Builds the site itself via the build-zfb composite action rather than
+  # downloading build-check's ~880 MB artifact. This removes the persisted
+  # artifact from the preview path (the biggest Actions-storage lever) at the
+  # cost of building the site twice per same-repo PR (once in build-check, once
+  # here). A red build still blocks the deploy two ways: this job needs
+  # quality-checks (typecheck/lint/format/unit), and its own build step runs
+  # before the deploy step, so a broken build fails the job before deploying.
   preview-deploy:
     name: Preview Deploy (Cloudflare Pages)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: build-check
+    timeout-minutes: 30
+    needs: quality-checks
     if: github.event.pull_request.head.repo.full_name == github.repository
 
     permissions:
@@ -340,11 +356,10 @@ jobs:
         with:
           lfs: false
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+      - name: Build zfb application
+        uses: ./.github/actions/build-zfb
         with:
-          name: zfb-build-pr-${{ github.event.pull_request.number }}
-          path: dist
+          node-version: '22'
 
       - name: Deploy to Cloudflare Pages Preview
         id: deploy

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -149,55 +149,13 @@ jobs:
         with:
           lfs: false
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@02f6c237bd2518259fed6c71566509edfb3f2b74 # v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      # Build (setup pnpm/node, install, build, verify output) via the shared
+      # composite action — same action preview-deploy and main-deploy use, so
+      # all paths build identically and the verify step can't drift.
+      - name: Build zfb application
+        uses: ./.github/actions/build-zfb
         with:
           node-version: '22'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build zfb site
-        run: pnpm build
-        env:
-          NODE_ENV: production
-          NODE_OPTIONS: '--max-old-space-size=4096'
-
-      - name: Verify build output
-        run: |
-          echo "Build Output Verification"
-          echo "========================="
-
-          if [ ! -d "dist" ]; then
-            echo "Error: dist/ directory not found"
-            exit 1
-          fi
-
-          # Count HTML files emitted by zfb + finalize
-          HTML_COUNT=$(find dist -name "*.html" | wc -l)
-          echo "HTML files: $HTML_COUNT"
-
-          # zfb-finalize-build.js merges everything under dist/manuals/
-          if [ -d "dist/manuals/assets" ]; then
-            echo "zfb assets found (dist/manuals/assets/)"
-          else
-            echo "Error: dist/manuals/assets/ not found"
-            exit 1
-          fi
-
-          # Cloudflare control files must be at dist/ root
-          if [ -f "dist/_headers" ]; then
-            echo "dist/_headers present"
-          else
-            echo "Error: dist/_headers not found at dist root"
-            exit 1
-          fi
-
-          echo "========================="
-          echo "Build output verified"
 
       # Only persist the ~880 MB build artifact where it is actually consumed:
       # the e2e-smoke-tests job runs on preview/* branches ONLY. On every other
@@ -216,6 +174,12 @@ jobs:
           retention-days: 1
 
   # Job 3: E2E Smoke Tests (only for preview/* branches)
+  #
+  # This is the ONLY consumer of build-check's uploaded artifact. Its
+  # `if:` predicate MUST stay in sync with the upload step's `if:` in
+  # build-check — if you ever widen this trigger, widen that upload gate
+  # too, or this job will try to download an artifact that was never
+  # uploaded.
   e2e-smoke-tests:
     name: E2E Smoke Tests
     runs-on: ubuntu-latest

--- a/doc/docs/inbox/csp-hardening-plan.md
+++ b/doc/docs/inbox/csp-hardening-plan.md
@@ -128,5 +128,3 @@ Worker forwarding to a logging service, or a third-party service (e.g.
 decision and is **not** part of the enforced flip. The directive currently has
 no `report-to`/`report-uri`, so violations surface only in each visitor's
 console.
-</content>
-</invoke>

--- a/doc/docs/inbox/csp-hardening-plan.md
+++ b/doc/docs/inbox/csp-hardening-plan.md
@@ -16,7 +16,7 @@ manuals site, and now records the **executed** enforced state.
 
 The viewer surface (`/*`) was flipped from `Content-Security-Policy-Report-Only`
 to **enforced** `Content-Security-Policy` in `public/_headers`. A docs carve-out
-keeps the Docusaurus site (`/manuals/doc/*`) on Report-Only.
+keeps the Docusaurus site (`/manuals/doc` and `/manuals/doc/*`) on Report-Only.
 
 Steps 2, 3, and 4 below were executed in this change. Step 1 (zero violations on
 the PR-preview proxied origin) is verified on the PR preview before the PR is
@@ -34,26 +34,35 @@ Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-hIolMSvWh
 - `style-src`: `'unsafe-inline'` **dropped** (Google Fonts origin kept) — see the
   audit result below.
 
-### Docs carve-out (`/manuals/doc/*`)
+### Docs carve-out (`/manuals/doc` + `/manuals/doc/*`)
 
 `pnpm build` copies the Docusaurus output into `dist/manuals/doc/`
 (`baseUrl: '/manuals/doc/'`), and Docusaurus output contains inline `<script>`
 and inline `<style>` that the enforced viewer policy would block. A naive global
-flip would therefore break `/manuals/doc/*`.
+flip would therefore break the docs site.
 
-The carve-out detaches the enforced header for that path and keeps docs on the
-previous docs-tolerant Report-Only directive (with `'unsafe-inline'` in both
-`script-src` and `style-src`):
+The carve-out detaches the enforced header for the docs path and keeps docs on
+the previous docs-tolerant Report-Only directive (with `'unsafe-inline'` in both
+`script-src` and `style-src`). **Two rules are needed**, because the
+`/manuals/doc/*` glob does NOT match the exact no-trailing-slash URL form
+`/manuals/doc` — a response served at that bare URL (the Docusaurus landing page)
+would otherwise fall through to the enforced `/*` policy and break on its inline
+scripts/styles. The exact `/manuals/doc` rule must be listed first, immediately
+before the glob:
 
 ```
+/manuals/doc
+  ! Content-Security-Policy
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
+
 /manuals/doc/*
   ! Content-Security-Policy
   Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
 ```
 
 `! Content-Security-Policy` is Cloudflare Pages' detach syntax: the `/*` rule
-sets the enforced header, then this more-specific rule removes it for the docs
-path and substitutes the Report-Only directive. The other security headers
+sets the enforced header, then these more-specific rules remove it for the docs
+path and substitute the Report-Only directive. The other security headers
 (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) are inherited
 from `/*` and still apply to docs. Hardening the docs CSP (hashing Docusaurus's
 inline scripts/styles, or enforcing a docs-specific policy) is deferred.

--- a/doc/docs/inbox/csp-hardening-plan.md
+++ b/doc/docs/inbox/csp-hardening-plan.md
@@ -7,63 +7,126 @@ sidebar_position: 70
 
 ## Why this document exists
 
-Cloudflare `_headers` files cannot contain comments. The flip-to-enforced plan that was documented in the commit message for `612cddf` (PR #156) would otherwise be completely undiscoverable from `public/_headers`. This document captures that plan so it is not lost.
+Cloudflare `_headers` files keep their rationale here rather than inline (the
+flip-to-enforced plan was originally captured only in the commit message for
+`612cddf`, PR #156). This document is the runbook of record for the CSP on the
+manuals site, and now records the **executed** enforced state.
 
-## Current header (Report-Only phase)
+## Executed state (2026-06-10, issue #164)
 
-`public/_headers` currently sets the following header on all routes (`/*`):
+The viewer surface (`/*`) was flipped from `Content-Security-Policy-Report-Only`
+to **enforced** `Content-Security-Policy` in `public/_headers`. A docs carve-out
+keeps the Docusaurus site (`/manuals/doc/*`) on Report-Only.
+
+Steps 2, 3, and 4 below were executed in this change. Step 1 (zero violations on
+the PR-preview proxied origin) is verified on the PR preview before the PR is
+merged — the change ships on a topic branch first.
+
+### Enforced directive (viewer surface `/*`)
 
 ```
-Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
+Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-hIolMSvWhopr46DqQi50arv0b3/qeN3LLlH0NTMq3K8='; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
 ```
 
-During the Report-Only phase the live site is unaffected by the policy — violations appear in the browser console only. This is intentional: the site is proxied through `takazudomodular.com/manuals/*` via a Netlify redirect, so a misconfigured enforced CSP could silently break hydration on the proxied origin in ways that `pnpm serve` on `localhost:8030` does NOT exercise.
+- `script-src`: `'unsafe-inline'` replaced with the SHA-256 hash of
+  `LANG_BOOTSTRAP_SCRIPT` (the only inline script). When a hash is present
+  browsers ignore `'unsafe-inline'`, so the swap is clean.
+- `style-src`: `'unsafe-inline'` **dropped** (Google Fonts origin kept) — see the
+  audit result below.
 
-## Flip-to-enforced criteria
+### Docs carve-out (`/manuals/doc/*`)
 
-Switch `Content-Security-Policy-Report-Only` → `Content-Security-Policy` only after all three steps below have been completed:
+`pnpm build` copies the Docusaurus output into `dist/manuals/doc/`
+(`baseUrl: '/manuals/doc/'`), and Docusaurus output contains inline `<script>`
+and inline `<style>` that the enforced viewer policy would block. A naive global
+flip would therefore break `/manuals/doc/*`.
+
+The carve-out detaches the enforced header for that path and keeps docs on the
+previous docs-tolerant Report-Only directive (with `'unsafe-inline'` in both
+`script-src` and `style-src`):
+
+```
+/manuals/doc/*
+  ! Content-Security-Policy
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
+```
+
+`! Content-Security-Policy` is Cloudflare Pages' detach syntax: the `/*` rule
+sets the enforced header, then this more-specific rule removes it for the docs
+path and substitutes the Report-Only directive. The other security headers
+(`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) are inherited
+from `/*` and still apply to docs. Hardening the docs CSP (hashing Docusaurus's
+inline scripts/styles, or enforcing a docs-specific policy) is deferred.
+
+## Flip-to-enforced criteria (reference)
+
+The viewer flip was gated on the steps below.
 
 ### Step 1 — Confirm zero violations on the PR-preview origin
 
-The PR preview URL (`https://pr-<N>.zmanuals.pages.dev/manuals/oxi-one-mk2/`) goes through the real Cloudflare Pages + Netlify proxy chain. Open the browser console on that origin and verify there are **zero CSP violation reports** for any legitimate scripts, styles, images, or fonts before proceeding.
+The PR preview URL (`https://pr-<N>.zmanuals.pages.dev/manuals/oxi-one-mk2/`)
+goes through the real Cloudflare Pages + Netlify proxy chain. Verify **zero CSP
+violations** in the browser console on that origin for both a viewer page **and**
+a `/manuals/doc/` page before merging. This is the pre-merge gate for the topic
+branch; it cannot be exercised by `pnpm serve` on `localhost:8030`.
 
-### Step 2 — Replace `script-src 'unsafe-inline'` with the SHA-256 hash
+### Step 2 — Replace `script-src 'unsafe-inline'` with the SHA-256 hash ✅ executed
 
-The only inline script on the page is `LANG_BOOTSTRAP_SCRIPT`, defined in `layouts/default.tsx`:
+The only inline script on the page is `LANG_BOOTSTRAP_SCRIPT`, defined in
+`layouts/default.tsx`:
 
 ```ts
 const LANG_BOOTSTRAP_SCRIPT = `(function(){try{var l=localStorage.getItem('zmanuals:lang');if(l==='en')document.documentElement.setAttribute('data-lang','en');}catch(e){}})();`;
 ```
 
-This string is a build-time constant and its content never changes, so its SHA-256 hash is stable. Compute it with:
+This string is a build-time constant and never changes, so its hash is stable.
+Compute it with:
 
 ```bash
 printf '%s' "(function(){try{var l=localStorage.getItem('zmanuals:lang');if(l==='en')document.documentElement.setAttribute('data-lang','en');}catch(e){}})();" \
   | openssl dgst -sha256 -binary | base64
 ```
 
-Replace `'unsafe-inline'` in `script-src` with `'sha256-<computed-hash>'`. When a hash is present, browsers ignore `'unsafe-inline'`, so the swap is clean and requires no other changes.
+Result: `sha256-hIolMSvWhopr46DqQi50arv0b3/qeN3LLlH0NTMq3K8=` (cross-checked by
+extracting the constant from source and hashing via `node` to avoid shell
+single-quote pitfalls). This value replaced `'unsafe-inline'` in `script-src`.
 
-### Step 3 — Audit `style-src 'unsafe-inline'`
+### Step 3 — Audit `style-src 'unsafe-inline'` ✅ executed — token dropped
 
-`'unsafe-inline'` was kept permissive for the Report-Only phase. Before flipping to enforced, audit whether any inline `<style>` elements or `style=` attributes remain in the rendered HTML. The Tailwind stylesheet is an external `<link rel="stylesheet">`, so it does not require `'unsafe-inline'`. Drop the token if no inline styles are found.
+Audited the rendered surface WITHOUT running `pnpm build`:
 
-### Step 4 — Rename the header
+- No `style=` attributes or `<style>` elements in `layouts/`, `components/`,
+  `pages/`, `lib/`, `styles/`, or `public/` (non-data).
+- No `style=` / `<style>` in any committed `public/*/data/pages-*.json` — this is
+  the HTML injected via `dangerouslySetInnerHTML` (`prose-content.tsx`
+  `contentHtml`).
+- `manual-app.tsx`'s `markerInnerHtml` only re-injects the captured SSR body; it
+  introduces no new inline styles.
+- The only `<style>` match repo-wide is in `scripts/pdf-render-browser.js`, a
+  build-time Puppeteer render script that never reaches the live site.
+- Programmatic `element.style.setProperty(...)` calls (e.g. the zoom lens in
+  `page-viewer.tsx`) are CSSOM mutations, which CSP `style-src` does **not**
+  govern — only HTML-parsed `style=`/`<style>` and external stylesheet origins.
+  Preact island hydration does not inject inline styles by itself.
 
-Rename the header in `public/_headers`:
+Conclusion: no inline styles on the viewer surface, so `'unsafe-inline'` was
+dropped from `style-src`. The Google Fonts stylesheet is an external
+`<link rel="stylesheet">`, so the `https://fonts.googleapis.com` origin is kept.
 
-```diff
--  Content-Security-Policy-Report-Only: default-src 'self'; ...
-+  Content-Security-Policy: default-src 'self'; ...
-```
+### Step 4 — Rename the header ✅ executed
 
-This is the actual "flip to enforced" step. It is a live-site security change and requires human sign-off before merging.
+`Content-Security-Policy-Report-Only` on `/*` was renamed to
+`Content-Security-Policy` (the enforced directive above). This is the live-site
+flip; it is verified on the PR preview (Step 1) before merge.
 
 ## Future options (not yet decided)
 
-Instead of console-only violation reporting, a **reporting endpoint** could be added to collect violations centrally. This would be configured via the `report-to` / `report-uri` directives and backed by either:
-
-- A lightweight Cloudflare Worker that forwards reports to a logging service, or
-- A third-party report collection service (e.g. [report-uri.com](https://report-uri.com))
-
-This is an infrastructure decision deferred for now. The console-only approach is sufficient for the current Report-Only observation phase.
+A **reporting endpoint** (`report-to` / `report-uri`) could collect violations
+centrally instead of console-only, backed by either a lightweight Cloudflare
+Worker forwarding to a logging service, or a third-party service (e.g.
+[report-uri.com](https://report-uri.com)). This remains an infrastructure
+decision and is **not** part of the enforced flip. The directive currently has
+no `report-to`/`report-uri`, so violations surface only in each visitor's
+console.
+</content>
+</invoke>

--- a/doc/docs/inbox/pr-preview-url.md
+++ b/doc/docs/inbox/pr-preview-url.md
@@ -12,7 +12,7 @@ Every same-repo pull request gets an automatic Cloudflare Pages preview deployme
 - Every pull request opened from a branch in this repository gets a preview at:
   - `https://pr-<N>.zmanuals.pages.dev/manuals/oxi-one-mk2/`
   - `<N>` is the pull request number (e.g. PR #42 → `https://pr-42.zmanuals.pages.dev/manuals/oxi-one-mk2/`).
-- Deployment runs automatically as the `preview-deploy` job in `.github/workflows/pr-quality-checks.yml` after `build-check` succeeds.
+- Deployment runs automatically as the `preview-deploy` job in `.github/workflows/pr-quality-checks.yml` after the `quality-checks` job (typecheck / lint / format / unit tests) succeeds. The job builds the site itself, so a broken build also fails the deploy.
 - A bot comment is posted / updated on the PR with the preview URL. The comment contains the marker `<!-- cf-preview-pr -->`, which the workflow uses to find and update the same comment on subsequent pushes.
 - A commit status is reported under the context `cloudflare/pr-preview`, so the preview link and its success/failure state are visible directly on the PR's Checks panel.
 
@@ -30,11 +30,13 @@ Every same-repo pull request gets an automatic Cloudflare Pages preview deployme
 - The `build-check` job still runs for forked PRs (it does not need secrets). Only the `preview-deploy` job is skipped.
 - If a fork contribution needs a live preview, a maintainer can push the branch to this repo as `preview/<name>` to run the named-preview flow.
 
-## Build artifact is reused (no double builds)
+## Build artifact is no longer persisted on the preview path
 
-- `build-check` uploads the built zfb site as an artifact named `zfb-build-pr-<N>` (where `<N>` is the PR number).
-- `preview-deploy` downloads the same `zfb-build-pr-<N>` artifact instead of rebuilding. There is exactly one `pnpm build` per PR push.
-- If `build-check` fails, `preview-deploy` does not run, so there is no attempt to deploy a broken build.
+The built zfb site is ~880 MB (the manuals carry a lot of media). Persisting it as an Actions artifact on every PR churned through the 2 GB Actions storage cap (see issue #175), so the preview path no longer uploads it:
+
+- `preview-deploy` **builds the site itself** via the `./.github/actions/build-zfb` composite action instead of downloading an artifact. This means the site is built twice per same-repo PR (once in `build-check`, once in `preview-deploy`) — accepted as the trade-off for not persisting the artifact. A red build still blocks the deploy: `preview-deploy` `needs: quality-checks`, and its own build step runs before the deploy step.
+- `build-check` only uploads the `zfb-build-pr-<N>` artifact when `github.head_ref` starts with `preview/` — i.e. only on the branches where the `e2e-smoke-tests` job actually consumes it. On all other PRs nothing is persisted to Actions storage.
+- The production path (`main-deploy.yml`) was merged into a single `build-and-deploy` job for the same reason: no artifact is uploaded/downloaded, and the build step gates the deploy step.
 
 ## Quick reference
 

--- a/e2e/viewer-ui.spec.ts
+++ b/e2e/viewer-ui.spec.ts
@@ -35,16 +35,19 @@ test.describe('Viewer UI: Sidebar Thumbnails', () => {
     const sidebar = page.locator('aside[aria-label="Page thumbnails"]');
     const sidebarBtn = page.locator('button[aria-label="Toggle sidebar"]');
 
-    // Initially hidden (translated off-screen)
-    await expect(sidebar).toHaveAttribute('aria-hidden', 'true');
+    // The sidebar is conditionally mounted ({sidebarOpen && thumbPages && ...}
+    // in manual-app.tsx): absent from the DOM while closed, mounted on open.
+    // Mounting also depends on the page-data fetch — the auto-waiting expect()
+    // polling below tolerates that delay.
+    await expect(sidebar).toHaveCount(0);
 
     // Open sidebar
     await sidebarBtn.click();
-    await expect(sidebar).toHaveAttribute('aria-hidden', 'false');
+    await expect(sidebar).toBeVisible();
 
     // Close sidebar
     await sidebarBtn.click();
-    await expect(sidebar).toHaveAttribute('aria-hidden', 'true');
+    await expect(sidebar).toHaveCount(0);
   });
 
   test('should highlight current page in sidebar', async ({ page }) => {

--- a/public/_headers
+++ b/public/_headers
@@ -2,6 +2,10 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-hIolMSvWhopr46DqQi50arv0b3/qeN3LLlH0NTMq3K8='; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
+
+/manuals/doc/*
+  ! Content-Security-Policy
   Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
 
 # Content-hashed JS/CSS bundles, safe to cache forever. Two prefixes during the

--- a/public/_headers
+++ b/public/_headers
@@ -4,6 +4,10 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-hIolMSvWhopr46DqQi50arv0b3/qeN3LLlH0NTMq3K8='; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
 
+/manuals/doc
+  ! Content-Security-Policy
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
+
 /manuals/doc/*
   ! Content-Security-Policy
   Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/takazudomodular-manuals/issues/187

---

## Summary

- Fixes the drifted sidebar e2e test so `e2e/viewer-ui.spec.ts` matches the shipped conditional-mount behavior (#185)
- Eliminates the ~880 MB persisted site-build artifact on the PR-preview and production-deploy paths — the biggest GitHub Actions storage lever (#175)
- Flips the site CSP from `Content-Security-Policy-Report-Only` to enforced `Content-Security-Policy`, with a sha256-hashed inline bootstrap script and a docs carve-out (#164)

## Changes

### #185 — e2e sidebar toggle test drift
- `e2e/viewer-ui.spec.ts`: the "open and close sidebar on toggle" test asserted `aria-hidden` on an always-mounted aside, which never matched any real implementation (the original Next.js sidebar used `translate-x` without aria-hidden; the zfb migration deliberately switched to conditional mount). Updated to assert `toHaveCount(0)` closed / `toBeVisible()` open / `toHaveCount(0)` closed again. Decision: kept shipped conditional-mount behavior; no implementation change.
- Verified: full `e2e/viewer-ui.spec.ts` suite passes against a fresh production build (13/13).

### #175 — Actions storage: site-build artifact churn
- `.github/workflows/pr-quality-checks.yml`:
  - `preview-deploy` now builds the site itself via the shared `./.github/actions/build-zfb` composite instead of downloading the ~880 MB `zfb-build-pr-*` artifact (`needs: quality-checks`, timeout 20→30 min). Red build still blocks deploy.
  - `build-check`'s artifact upload is now gated `if: startsWith(github.head_ref, 'preview/')` — only `e2e-smoke-tests` (preview/* only) consumes it; on all other PRs nothing is persisted.
  - `build-check` deduped onto the same composite action so all build paths stay identical.
- `.github/workflows/main-deploy.yml`: merged build+deploy into a single `build-and-deploy` job — no production artifact persisted either. Build step still gates the deploy step.
- `doc/docs/inbox/pr-preview-url.md` updated to match.
- Trade-off accepted: same-repo PRs build twice (build-check + preview-deploy).

### #164 — CSP flip to enforced
- `public/_headers`:
  - `/*` header renamed `Content-Security-Policy-Report-Only` → `Content-Security-Policy`.
  - `script-src 'unsafe-inline'` replaced with `'sha256-hIolMSvWhopr46DqQi50arv0b3/qeN3LLlH0NTMq3K8='` (hash of the `LANG_BOOTSTRAP_SCRIPT` constant in `layouts/default.tsx`).
  - `style-src 'unsafe-inline'` dropped after a clean audit (no inline styles in source or committed page data; Google Fonts origin kept).
  - Docs carve-out: `/manuals/doc` (exact) and `/manuals/doc/*` both detach the enforced header (`! Content-Security-Policy`, Cloudflare syntax) and keep docs on Report-Only — Docusaurus output contains inline scripts/styles that the enforced policy would break. The exact-URL rule covers the no-trailing-slash form (deep-review finding).
- `doc/docs/inbox/csp-hardening-plan.md`: runbook updated to executed state (steps done, current directives, carve-out rationale, report-to endpoint left as future option).

## Test Plan

- CI green on this PR (all checks; preview deploy ran the new self-build path with nothing uploaded to Actions storage)
- `npx playwright test e2e/viewer-ui.spec.ts` → 13/13 pass against fresh production build
- PR preview verified via headers + headless browser:
  - Viewer page: enforced CSP header present, console completely clean (hashed inline script executes, hydration works, page image renders)
  - `/manuals/doc/` and bare `/manuals/doc`: Report-Only only (carve-out works on both URL forms), Docusaurus fully styled
- After merge: confirm production deploy goes green on `main` and the proxied origin (takazudomodular.com/manuals/) shows no CSP violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
