### PR TITLE
fix: deploy-cloudflare build-dir default + docs favicon (#189, #190)

### DIFF
--- a/.github/actions/deploy-cloudflare/action.yml
+++ b/.github/actions/deploy-cloudflare/action.yml
@@ -27,7 +27,7 @@ inputs:
   build-dir:
     description: 'Directory containing build output'
     required: false
-    default: 'out'
+    default: 'dist'
 
 outputs:
   deploy-url:

--- a/doc/docusaurus.config.ts
+++ b/doc/docusaurus.config.ts
@@ -5,7 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 const config: Config = {
   title: 'Takazudo Modular: Manuals',
   tagline: 'Development documentation for manual viewer',
-  // favicon: 'img/favicon.ico', // TODO: Add favicon later
+  favicon: 'img/logo.svg',
 
   // Set the production url of your site here
   url: 'https://manual-oxi-one-mk2.netlify.app',


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/takazudomodular-manuals/issues/189
    - https://github.com/Takazudo/takazudomodular-manuals/issues/190

---

## Summary

Auto-fix bundle for two `agent-found` findings raised during the recent-issues-0610 batch session (root PR #188):

- Closes #189 — `deploy-cloudflare` composite action's `build-dir` default was still `out` (Next.js era); the project emits `dist/` since the zfb migration. All callers override the input, so this was latent only — but the stale default was a footgun for future callers. Default corrected to `dist`.
- Closes #190 — `/manuals/doc/` pages 404'd on `favicon.ico` because no favicon was configured. Pointed Docusaurus `favicon` at the existing `static/img/logo.svg`, which emits a `<link rel="icon">` and stops the default favicon request.

## Test Plan

- CI quality checks + build (doc build consumes the new `favicon` config)
- PR preview: confirm `<link rel="icon" href="/manuals/doc/img/logo.svg">` in docs HTML and no favicon.ico console 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
