### PR TITLE
fix(e2e): wait for island readiness + fix broken nav/scroll assertions

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,13 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Wait until the manual-app island has fetched page data and swapped in the
+ * interactive viewer. In-manual navigation (arrow keys, prev/next, selector)
+ * is gated on that fetch (`navDisabled` in manual-app.tsx), so interacting
+ * before this point silently does nothing. The page selector is the
+ * deterministic signal: the SSR shell renders no PageNavigation at all, and
+ * the selector only appears enabled once the real viewer is mounted.
+ */
+export async function waitForViewerNavReady(page: Page): Promise<void> {
+  await expect(page.getByTestId('page-selector')).toBeEnabled({ timeout: 15000 });
+}

--- a/e2e/oxi-one-mk2-viewer.spec.ts
+++ b/e2e/oxi-one-mk2-viewer.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
-import manifest from '../public/oxi-one-mk2/data/manifest.json';
+import manifest from '../public/oxi-one-mk2/data/manifest.json' with { type: 'json' };
+import { waitForViewerNavReady } from './helpers';
 
 const MANUAL_ID = 'oxi-one-mk2';
 const MANUAL_PATH = `/manuals/${MANUAL_ID}/page`;
@@ -118,6 +119,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
   test.describe('Keyboard Navigation', () => {
     test('should navigate to next page with ArrowRight', async ({ page }) => {
       await page.goto(`${MANUAL_PATH}/1`);
+      await waitForViewerNavReady(page);
 
       // Press ArrowRight
       await page.keyboard.press('ArrowRight');
@@ -131,6 +133,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
 
     test('should navigate to previous page with ArrowLeft', async ({ page }) => {
       await page.goto(`${MANUAL_PATH}/2`);
+      await waitForViewerNavReady(page);
 
       // Press ArrowLeft
       await page.keyboard.press('ArrowLeft');
@@ -142,19 +145,20 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
       await expect(page).toHaveURL(`${MANUAL_PATH}/1`);
     });
 
-    test('should not navigate before page 1 with ArrowLeft', async ({ page }) => {
+    test('should navigate to manual top with ArrowLeft on page 1', async ({ page }) => {
       await page.goto(`${MANUAL_PATH}/1`);
-      const initialUrl = page.url();
+      await waitForViewerNavReady(page);
 
-      // Press ArrowLeft (should not navigate)
+      // ArrowLeft on page 1 deliberately goes to the manual landing page
+      // (navigateHome branch in keyboard-navigation.tsx), not "nowhere".
       await page.keyboard.press('ArrowLeft');
 
-      // Verify URL hasn't changed
-      await expect(page).toHaveURL(initialUrl);
+      await expect(page).toHaveURL(`/manuals/${MANUAL_ID}`);
     });
 
     test('should not navigate beyond last page with ArrowRight', async ({ page }) => {
       await page.goto(`${MANUAL_PATH}/${TOTAL_PAGES}`);
+      await waitForViewerNavReady(page);
       const initialUrl = page.url();
 
       // Press ArrowRight (should not navigate)
@@ -311,7 +315,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
 
       // Wait for navigation
       await page.waitForURL(`${MANUAL_PATH}/11`);
-      expect(page.url()).toBe(`${MANUAL_PATH}/11`);
+      await expect(page).toHaveURL(`${MANUAL_PATH}/11`);
 
       // Click prev button
       const prevButton = page.getByTestId('prev-page-button');
@@ -319,7 +323,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
 
       // Wait for navigation
       await page.waitForURL(`${MANUAL_PATH}/10`);
-      expect(page.url()).toBe(`${MANUAL_PATH}/10`);
+      await expect(page).toHaveURL(`${MANUAL_PATH}/10`);
     });
 
     test('should navigate using page selector', async ({ page }) => {
@@ -331,7 +335,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
 
       // Wait for navigation
       await page.waitForURL(`${MANUAL_PATH}/50`);
-      expect(page.url()).toBe(`${MANUAL_PATH}/50`);
+      await expect(page).toHaveURL(`${MANUAL_PATH}/50`);
 
       // Verify page selector shows correct page
       await expect(pageSelector).toHaveValue('50');

--- a/e2e/scroll-mode.spec.ts
+++ b/e2e/scroll-mode.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { waitForViewerNavReady } from './helpers';
 
 const MANUAL_PATH = '/manuals/oxi-one-mk2/page';
 
@@ -18,6 +19,9 @@ const MANUAL_PATH = '/manuals/oxi-one-mk2/page';
 
 /** Switch from page mode to scroll mode and wait for viewer to be ready */
 async function switchToScrollMode(page: Page) {
+  // Wait for the island to be interactive first — a click on the SSR'd button
+  // before hydration is silently lost (no listener attached yet).
+  await waitForViewerNavReady(page);
   const viewModeBtn = page.locator('button[aria-label="Switch to scroll mode"]');
   await viewModeBtn.click();
   const scrollViewer = page.getByTestId('scroll-viewer');
@@ -40,9 +44,11 @@ test.describe('Scroll Mode: Page Detection', () => {
       el.scrollTop = el.scrollHeight * 0.05;
     });
 
-    // Wait for IntersectionObserver to detect new page (condition-based, not fixed delay)
-    await expect(page.getByTestId('scroll-translation-header')).not.toContainText('P.1', {
-      timeout: 3000,
+    // Wait for IntersectionObserver to detect new page (condition-based, not
+    // fixed delay). Match "P.1 /" with the boundary — a bare "P.1" is a
+    // substring of "P.16 / 302" and would never stop matching.
+    await expect(page.getByTestId('scroll-translation-header')).not.toContainText('P.1 /', {
+      timeout: 8000,
     });
 
     // Extract detected page number and verify it advanced


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/takazudomodular-manuals/issues/194

---

## Summary

Fixes the 6 consistently-failing e2e tests found during the zfb next.38 bump verification (#193). Three distinct test bugs:

- **Data-ready race** (keyboard/scroll tests): interactions fired right after `goto`, racing the island's `pages-ja.json` fetch (`navDisabled` gate in `manual-app.tsx`). New `e2e/helpers.ts#waitForViewerNavReady()` waits for the enabled `page-selector`, which only renders once the interactive viewer is mounted (the SSR shell renders no PageNavigation).
- **URL assertion bug** (Navigation UI ×2, failed on every machine): `expect(page.url()).toBe('/manuals/...')` compared an absolute URL against a path. Now `await expect(page).toHaveURL(path)`.
- **Substring assertion bug** (scroll-mode): `not.toContainText('P.1')` matches `"P.16 / 302"`. Now matches the `'P.1 /'` boundary.

Also, the "should not navigate before page 1" test now asserts the app's actual designed behavior — ArrowLeft on page 1 deliberately navigates to the manual landing page (`navigateHome` branch in `keyboard-navigation.tsx`). The old expectation only ever passed because the keypress was lost pre-hydration.

The JSON import attribute line duplicates #193's identical one-liner (required to run the suite on Node ≥24); the branches merge cleanly in either order.

## Verification

- Full Playwright suite: **102/102 pass** locally on the machine where 6 previously failed (96/102)
- `pnpm check`: pass
- Codex review: no actionable findings

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)