### PR TITLE
fix 6 agent-found issues: deps hygiene, formatter scope, e2e CI

### DIFF
--- a/.github/workflows/main-e2e.yml
+++ b/.github/workflows/main-e2e.yml
@@ -1,0 +1,82 @@
+name: Main E2E (full Playwright suite)
+
+# Runs the FULL Playwright e2e suite on every push to main.
+#
+# This is intentionally a SEPARATE workflow from main-deploy.yml: the
+# production deploy does NOT depend on it. Failures here are visible (red check
+# on the commit) but never block a deploy — the suite is post-merge regression
+# detection, not a gate. To disable, delete this one file; nothing else
+# references it.
+on:
+  push:
+    branches:
+      - main
+
+# Independent of the production-deploy concurrency group so this never serializes
+# with or blocks deploys. Newer pushes cancel an in-flight e2e run.
+concurrency:
+  group: main-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-full:
+    name: Full Playwright Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          lfs: false
+
+      # Setup pnpm/node, install deps, and build dist/ via the shared composite
+      # action — same build the deploy uses, so the suite tests what ships.
+      - name: Build zfb application
+        uses: ./.github/actions/build-zfb
+        with:
+          node-version: '22'
+
+      - name: Resolve Playwright version
+        id: pw
+        run: |
+          PW_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")
+          echo "version=$PW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Playwright version: $PW_VERSION"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright chromium (+ system deps)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cached browser)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      # Full suite (all specs incl. all-pages) against the already-built dist/.
+      # Playwright owns the serve via webServer + SKIP_ZFB_BUILD=1.
+      - name: Run full Playwright suite
+        env:
+          SKIP_ZFB_BUILD: '1'
+        run: |
+          echo "🎭 Running the full Playwright suite..."
+          npx playwright test
+          echo "✅ Full suite passed"
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: playwright-traces-main-${{ github.sha }}
+          path: test-results/
+          retention-days: 3
+          if-no-files-found: ignore

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -158,7 +158,7 @@ jobs:
           node-version: '22'
 
       # Only persist the ~880 MB build artifact where it is actually consumed:
-      # the e2e-smoke-tests job runs on preview/* branches ONLY. On every other
+      # the page-smoke-crawler job runs on preview/* branches ONLY. On every other
       # PR the artifact would be uploaded, count against the 2 GB Actions storage
       # cap, and never be downloaded. preview-deploy now builds the site itself
       # instead of consuming this artifact, so this upload is preview/* only.
@@ -173,15 +173,20 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
-  # Job 3: E2E Smoke Tests (only for preview/* branches)
+  # Job 3: Page Smoke Crawler (only for preview/* branches)
+  #
+  # NOT Playwright — this runs scripts/test-all-pages-fast.js, a plain HTTP-status
+  # crawler that GETs every /manuals/<id>/page/<n> route of every manual and
+  # asserts HTTP 200. Browser-level interaction is covered separately by the
+  # e2e-interaction job (Playwright) and the main-e2e workflow.
   #
   # This is the ONLY consumer of build-check's uploaded artifact. Its
   # `if:` predicate MUST stay in sync with the upload step's `if:` in
   # build-check — if you ever widen this trigger, widen that upload gate
   # too, or this job will try to download an artifact that was never
   # uploaded.
-  e2e-smoke-tests:
-    name: E2E Smoke Tests
+  page-smoke-crawler:
+    name: Page Smoke Crawler
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: build-check
@@ -247,7 +252,7 @@ jobs:
             kill $SERVER_PID || true
           fi
 
-      - name: Comment e2e test status
+      - name: Comment page smoke crawler status
         if: always()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
@@ -256,11 +261,11 @@ jobs:
             const emoji = success ? '✅' : '❌';
             const status = success ? 'passed' : 'failed';
 
-            const body = `${emoji} **E2E Smoke Tests ${status}**
+            const body = `${emoji} **Page Smoke Crawler ${status}**
 
-            Tested all manual pages against production build.
+            HTTP-status crawl of every manual's pages against the production build (not a browser test).
 
-            ${success ? '✅ All pages loaded successfully with HTTP 200.' : '❌ Some pages failed to load. Check the logs for details.'}`;
+            ${success ? '✅ Every manual page returned HTTP 200.' : '❌ Some pages failed to load. Check the logs for details.'}`;
 
             // Find existing comment
             const { data: comments } = await github.rest.issues.listComments({
@@ -271,7 +276,7 @@ jobs:
 
             const botComment = comments.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('E2E Smoke Tests')
+              comment.body.includes('Page Smoke Crawler')
             );
 
             if (botComment) {
@@ -292,7 +297,96 @@ jobs:
               });
             }
 
-  # Job 4: Preview Deploy (Cloudflare Pages) for same-repo PRs
+  # Job 4: E2E Interaction Tests (Playwright) — runs on ALL PRs
+  #
+  # Runs the browser-level Playwright interaction specs (NOT the all-pages
+  # crawler — page loads are covered by page-smoke-crawler and the main-e2e
+  # workflow). This is the only CI path that would have caught the broken
+  # navigation/scroll assertions that sat on main for ~5 months (#196).
+  #
+  # Builds the site IN-JOB via the build-zfb composite action and runs
+  # Playwright with SKIP_ZFB_BUILD=1 against that build — deliberately NOT
+  # consuming build-check's ~880 MB artifact (the workflow warns about the 2 GB
+  # Actions storage cap). Chromium is cached on ~/.cache/ms-playwright keyed on
+  # the installed Playwright version.
+  #
+  # No `branches:` filter exists on this workflow's pull_request trigger, so
+  # this job fires for PRs targeting ANY base branch (e.g. topic/* base
+  # branches), not just main. Do NOT add a branches filter without revisiting
+  # this.
+  e2e-interaction:
+    name: E2E Interaction Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: quality-checks
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          lfs: false
+
+      # Setup pnpm/node, install deps, and build dist/ — same composite action
+      # the deploy paths use, so the e2e build can't drift from production.
+      - name: Build zfb application
+        uses: ./.github/actions/build-zfb
+        with:
+          node-version: '22'
+
+      - name: Resolve Playwright version
+        id: pw
+        run: |
+          PW_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")
+          echo "version=$PW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Playwright version: $PW_VERSION"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+
+      # Cache hit: only (re)install the OS-level deps (apt packages live outside
+      # ~/.cache/ms-playwright and are never cached). Cache miss: download the
+      # chromium browser plus its system deps.
+      - name: Install Playwright chromium (+ system deps)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cached browser)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      # Run ONLY the interaction specs against the already-built dist/ (Playwright
+      # owns the serve via webServer + SKIP_ZFB_BUILD=1). all-pages.spec.ts is
+      # intentionally excluded — page loads are the crawler's job.
+      - name: Run Playwright interaction specs
+        env:
+          SKIP_ZFB_BUILD: '1'
+        run: |
+          echo "🎭 Running Playwright interaction specs..."
+          npx playwright test \
+            e2e/oxi-one-mk2-viewer.spec.ts \
+            e2e/scroll-mode.spec.ts \
+            e2e/language-toggle.spec.ts \
+            e2e/viewer-ui.spec.ts
+          echo "✅ Interaction specs passed"
+
+      # On failure only: persist the on-retry traces (config uses the 'list'
+      # reporter + trace:'on-first-retry', so there is no playwright-report/ dir;
+      # failing tests drop a trace under test-results/). Tiny + 3-day retention
+      # keeps this well clear of the 2 GB Actions storage cap.
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: playwright-traces-pr-${{ github.event.pull_request.number }}
+          path: test-results/
+          retention-days: 3
+          if-no-files-found: ignore
+
+  # Job 5: Preview Deploy (Cloudflare Pages) for same-repo PRs
   #
   # Builds the site itself via the build-zfb composite action rather than
   # downloading build-check's ~880 MB artifact. This removes the persisted

--- a/doc/package.json
+++ b/doc/package.json
@@ -20,11 +20,11 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.9.2",
+    "@docusaurus/core": "3.9.2",
     "@docusaurus/plugin-content-docs": "3.9.2",
-    "@docusaurus/preset-classic": "^3.9.2",
+    "@docusaurus/preset-classic": "3.9.2",
     "@docusaurus/theme-common": "3.9.2",
-    "@docusaurus/theme-mermaid": "^3.9.2",
+    "@docusaurus/theme-mermaid": "3.9.2",
     "@easyops-cn/docusaurus-search-local": "^0.52.3",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
@@ -33,9 +33,9 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.9.2",
-    "@docusaurus/tsconfig": "^3.9.2",
-    "@docusaurus/types": "^3.9.2",
+    "@docusaurus/module-type-aliases": "3.9.2",
+    "@docusaurus/tsconfig": "3.9.2",
+    "@docusaurus/types": "3.9.2",
     "gray-matter": "^4.0.3",
     "typescript": "~5.9.3"
   },

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,13 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Wait until the manual-app island has fetched page data and swapped in the
+ * interactive viewer. In-manual navigation (arrow keys, prev/next, selector)
+ * is gated on that fetch (`navDisabled` in manual-app.tsx), so interacting
+ * before this point silently does nothing. The page selector is the
+ * deterministic signal: the SSR shell renders no PageNavigation at all, and
+ * the selector only appears enabled once the real viewer is mounted.
+ */
+export async function waitForViewerNavReady(page: Page): Promise<void> {
+  await expect(page.getByTestId('page-selector')).toBeEnabled({ timeout: 15000 });
+}

--- a/e2e/oxi-one-mk2-viewer.spec.ts
+++ b/e2e/oxi-one-mk2-viewer.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
-import manifest from '../public/oxi-one-mk2/data/manifest.json';
+import manifest from '../public/oxi-one-mk2/data/manifest.json' with { type: 'json' };
+import { waitForViewerNavReady } from './helpers';
 
 const MANUAL_ID = 'oxi-one-mk2';
 const MANUAL_PATH = `/manuals/${MANUAL_ID}/page`;
@@ -118,6 +119,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
   test.describe('Keyboard Navigation', () => {
     test('should navigate to next page with ArrowRight', async ({ page }) => {
       await page.goto(`${MANUAL_PATH}/1`);
+      await waitForViewerNavReady(page);
 
       // Press ArrowRight
       await page.keyboard.press('ArrowRight');
@@ -131,6 +133,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
 
     test('should navigate to previous page with ArrowLeft', async ({ page }) => {
       await page.goto(`${MANUAL_PATH}/2`);
+      await waitForViewerNavReady(page);
 
       // Press ArrowLeft
       await page.keyboard.press('ArrowLeft');
@@ -142,19 +145,20 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
       await expect(page).toHaveURL(`${MANUAL_PATH}/1`);
     });
 
-    test('should not navigate before page 1 with ArrowLeft', async ({ page }) => {
+    test('should navigate to manual top with ArrowLeft on page 1', async ({ page }) => {
       await page.goto(`${MANUAL_PATH}/1`);
-      const initialUrl = page.url();
+      await waitForViewerNavReady(page);
 
-      // Press ArrowLeft (should not navigate)
+      // ArrowLeft on page 1 deliberately goes to the manual landing page
+      // (navigateHome branch in keyboard-navigation.tsx), not "nowhere".
       await page.keyboard.press('ArrowLeft');
 
-      // Verify URL hasn't changed
-      await expect(page).toHaveURL(initialUrl);
+      await expect(page).toHaveURL(`/manuals/${MANUAL_ID}`);
     });
 
     test('should not navigate beyond last page with ArrowRight', async ({ page }) => {
       await page.goto(`${MANUAL_PATH}/${TOTAL_PAGES}`);
+      await waitForViewerNavReady(page);
       const initialUrl = page.url();
 
       // Press ArrowRight (should not navigate)
@@ -311,7 +315,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
 
       // Wait for navigation
       await page.waitForURL(`${MANUAL_PATH}/11`);
-      expect(page.url()).toBe(`${MANUAL_PATH}/11`);
+      await expect(page).toHaveURL(`${MANUAL_PATH}/11`);
 
       // Click prev button
       const prevButton = page.getByTestId('prev-page-button');
@@ -319,7 +323,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
 
       // Wait for navigation
       await page.waitForURL(`${MANUAL_PATH}/10`);
-      expect(page.url()).toBe(`${MANUAL_PATH}/10`);
+      await expect(page).toHaveURL(`${MANUAL_PATH}/10`);
     });
 
     test('should navigate using page selector', async ({ page }) => {
@@ -331,7 +335,7 @@ test.describe('OXI ONE MKII Manual Viewer', () => {
 
       // Wait for navigation
       await page.waitForURL(`${MANUAL_PATH}/50`);
-      expect(page.url()).toBe(`${MANUAL_PATH}/50`);
+      await expect(page).toHaveURL(`${MANUAL_PATH}/50`);
 
       // Verify page selector shows correct page
       await expect(pageSelector).toHaveValue('50');

--- a/e2e/scroll-mode.spec.ts
+++ b/e2e/scroll-mode.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { waitForViewerNavReady } from './helpers';
 
 const MANUAL_PATH = '/manuals/oxi-one-mk2/page';
 
@@ -18,6 +19,9 @@ const MANUAL_PATH = '/manuals/oxi-one-mk2/page';
 
 /** Switch from page mode to scroll mode and wait for viewer to be ready */
 async function switchToScrollMode(page: Page) {
+  // Wait for the island to be interactive first — a click on the SSR'd button
+  // before hydration is silently lost (no listener attached yet).
+  await waitForViewerNavReady(page);
   const viewModeBtn = page.locator('button[aria-label="Switch to scroll mode"]');
   await viewModeBtn.click();
   const scrollViewer = page.getByTestId('scroll-viewer');
@@ -40,9 +44,11 @@ test.describe('Scroll Mode: Page Detection', () => {
       el.scrollTop = el.scrollHeight * 0.05;
     });
 
-    // Wait for IntersectionObserver to detect new page (condition-based, not fixed delay)
-    await expect(page.getByTestId('scroll-translation-header')).not.toContainText('P.1', {
-      timeout: 3000,
+    // Wait for IntersectionObserver to detect new page (condition-based, not
+    // fixed delay). Match "P.1 /" with the boundary — a bare "P.1" is a
+    // substring of "P.16 / 302" and would never stop matching.
+    await expect(page.getByTestId('scroll-translation-header')).not.toContainText('P.1 /', {
+      timeout: 8000,
     });
 
     // Extract detected page number and verify it advanced

--- a/e2e/viewer-ui.spec.ts
+++ b/e2e/viewer-ui.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { waitForViewerNavReady } from './helpers';
 
 const PAGE_URL = '/manuals/oxi-one-mk2/page/5';
 
@@ -31,6 +32,7 @@ test.describe('Viewer UI: Header Utility Bar', () => {
 test.describe('Viewer UI: Sidebar Thumbnails', () => {
   test('should open and close sidebar on toggle', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     const sidebar = page.locator('aside[aria-label="Page thumbnails"]');
     const sidebarBtn = page.locator('button[aria-label="Toggle sidebar"]');
@@ -52,6 +54,7 @@ test.describe('Viewer UI: Sidebar Thumbnails', () => {
 
   test('should highlight current page in sidebar', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     const sidebarBtn = page.locator('button[aria-label="Toggle sidebar"]');
     await sidebarBtn.click();
@@ -72,6 +75,7 @@ test.describe('Viewer UI: Sidebar Thumbnails', () => {
 
   test('should navigate when clicking a sidebar thumbnail', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     const sidebarBtn = page.locator('button[aria-label="Toggle sidebar"]');
     await sidebarBtn.click();
@@ -90,6 +94,7 @@ test.describe('Viewer UI: Sidebar Thumbnails', () => {
 test.describe('Viewer UI: Thumbnail Grid Modal', () => {
   test('should open and close modal', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     const thumbsBtn = page.locator('button[aria-label="Open thumbnail grid"]');
     await thumbsBtn.click();
@@ -108,6 +113,7 @@ test.describe('Viewer UI: Thumbnail Grid Modal', () => {
 
   test('should close modal with Escape key', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     const thumbsBtn = page.locator('button[aria-label="Open thumbnail grid"]');
     await thumbsBtn.click();
@@ -121,6 +127,7 @@ test.describe('Viewer UI: Thumbnail Grid Modal', () => {
 
   test('should close modal when clicking overlay', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     const thumbsBtn = page.locator('button[aria-label="Open thumbnail grid"]');
     await thumbsBtn.click();
@@ -135,6 +142,7 @@ test.describe('Viewer UI: Thumbnail Grid Modal', () => {
 
   test('should navigate when clicking a thumbnail in modal', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     const thumbsBtn = page.locator('button[aria-label="Open thumbnail grid"]');
     await thumbsBtn.click();
@@ -153,6 +161,7 @@ test.describe('Viewer UI: Thumbnail Grid Modal', () => {
 
   test('should show thumbnail grid with proper aspect ratio', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     const thumbsBtn = page.locator('button[aria-label="Open thumbnail grid"]');
     await thumbsBtn.click();
@@ -170,6 +179,7 @@ test.describe('Viewer UI: Thumbnail Grid Modal', () => {
 test.describe('Viewer UI: View Mode Toggle', () => {
   test('should switch to scroll mode and back', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     // Initially in page mode
     const pageViewer = page.getByTestId('page-image-column');
@@ -193,6 +203,7 @@ test.describe('Viewer UI: View Mode Toggle', () => {
 
   test('scroll mode should show page images', async ({ page }) => {
     await page.goto(PAGE_URL);
+    await waitForViewerNavReady(page);
 
     // Switch to scroll mode
     const viewModeBtn = page.locator('button[aria-label="Switch to scroll mode"]');
@@ -262,6 +273,7 @@ test.describe('Viewer UI: No Console Errors', () => {
 
     await page.goto(PAGE_URL);
     await page.waitForLoadState('networkidle');
+    await waitForViewerNavReady(page);
 
     // Toggle sidebar
     await page.locator('button[aria-label="Toggle sidebar"]').click();

--- a/package.json
+++ b/package.json
@@ -105,18 +105,16 @@
     "@types/node": "25.5.0",
     "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@typescript-eslint/parser": "^8.57.2",
-    "@vitejs/plugin-react": "^4.7.0",
     "canvas": "^3.2.2",
     "eslint": "^10.1.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "glob": "^13.0.6",
     "image-size": "^2.0.2",
     "jsdom": "^29.0.1",
     "lint-staged": "^16.4.0",
     "pdf-lib": "^1.17.1",
     "pdf-parse": "^2.4.5",
-    "pdf-poppler": "^0.2.3",
     "pdf-to-png-converter": "^3.14.0",
     "pdfjs-dist": "^5.5.207",
     "prettier": "^3.8.1",
@@ -150,12 +148,6 @@
     ],
     "!(worktrees|__inbox|node_modules)/**/*.{json,css,yml,yaml}": [
       "prettier --write"
-    ]
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "workerd"
     ]
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,15 @@ import { defineConfig, devices } from '@playwright/test';
 // scripts/zfb-finalize-build.js && pnpm serve`.
 const ZFB_SERVE_URL = 'http://localhost:8030';
 
+// Serve the already-finalized dist/ without rebuilding. CI builds the site
+// once via the build-zfb composite action, then runs Playwright with
+// SKIP_ZFB_BUILD=1 so the test runner doesn't rebuild from scratch.
+const SERVE_DIST_CMD = 'pnpm dlx serve dist -l 8030';
+// Full build chain (zfb build + finalize) before serving — the default for
+// local runs where no dist exists yet.
+const BUILD_AND_SERVE_CMD = `pnpm zfb:build && node scripts/zfb-finalize-build.js && ${SERVE_DIST_CMD}`;
+const SKIP_ZFB_BUILD = process.env.SKIP_ZFB_BUILD === '1';
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -37,10 +46,11 @@ export default defineConfig({
   // move them to a separate spec that runs only against the deployed preview.
   webServer: {
     // Build the zfb dist + finalize + serve in sequence so the test runner
-    // starts against a fully baked production bundle. If a dist already exists
-    // and you want to skip the rebuild, set SKIP_ZFB_BUILD=1 and start the
-    // server manually before running playwright.
-    command: 'pnpm zfb:build && node scripts/zfb-finalize-build.js && pnpm dlx serve dist -l 8030',
+    // starts against a fully baked production bundle. Set SKIP_ZFB_BUILD=1 to
+    // skip the rebuild and serve an existing dist/ directly — Playwright still
+    // owns the server lifecycle (start/stop), so no manual server step is
+    // needed. CI uses this after building once via the build-zfb action.
+    command: SKIP_ZFB_BUILD ? SERVE_DIST_CMD : BUILD_AND_SERVE_CMD,
     url: ZFB_SERVE_URL,
     reuseExistingServer: !process.env.CI,
     stdout: 'ignore',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
-      '@vitejs/plugin-react':
-        specifier: ^4.7.0
-        version: 4.7.0(vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.0))
       canvas:
         specifier: ^3.2.2
         version: 3.2.2
@@ -70,8 +67,8 @@ importers:
         specifier: ^7.37.5
         version: 7.37.5(eslint@10.1.0(jiti@2.6.1))
       eslint-plugin-react-hooks:
-        specifier: ^7.0.1
-        version: 7.0.1(eslint@10.1.0(jiti@2.6.1))
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@10.1.0(jiti@2.6.1))
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -90,9 +87,6 @@ importers:
       pdf-parse:
         specifier: ^2.4.5
         version: 2.4.5
-      pdf-poppler:
-        specifier: ^0.2.3
-        version: 0.2.3
       pdf-to-png-converter:
         specifier: ^3.14.0
         version: 3.14.0
@@ -145,19 +139,19 @@ importers:
   doc:
     dependencies:
       '@docusaurus/core':
-        specifier: ^3.9.2
+        specifier: 3.9.2
         version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(debug@4.4.3)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/plugin-content-docs':
         specifier: 3.9.2
         version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(debug@4.4.3)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/preset-classic':
-        specifier: ^3.9.2
+        specifier: 3.9.2
         version: 3.9.2(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
       '@docusaurus/theme-common':
         specifier: 3.9.2
         version: 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-mermaid':
-        specifier: ^3.9.2
+        specifier: 3.9.2
         version: 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@easyops-cn/docusaurus-search-local':
         specifier: ^0.52.3
@@ -179,13 +173,13 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@docusaurus/module-type-aliases':
-        specifier: ^3.9.2
+        specifier: 3.9.2
         version: 3.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/tsconfig':
-        specifier: ^3.9.2
+        specifier: 3.9.2
         version: 3.9.2
       '@docusaurus/types':
-        specifier: ^3.9.2
+        specifier: 3.9.2
         version: 3.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gray-matter:
         specifier: ^4.0.3
@@ -347,24 +341,12 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.5':
-    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.28.5':
-    resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/core@7.29.0':
     resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.1':
@@ -373,10 +355,6 @@ packages:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.28.6':
@@ -408,19 +386,9 @@ packages:
     resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.28.6':
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
 
   '@babel/helper-module-transforms@7.28.6':
     resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
@@ -466,10 +434,6 @@ packages:
 
   '@babel/helper-wrap-function@7.28.6':
     resolution: {integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.29.2':
@@ -809,18 +773,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-react-jsx@7.28.6':
     resolution: {integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==}
     engines: {node: '>=6.9.0'}
@@ -948,16 +900,8 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.0':
@@ -2672,9 +2616,6 @@ packages:
       preact: ^10.4.0 || ^11.0.0-0
       vite: '>=2.0.0'
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
-
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
@@ -3081,18 +3022,6 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
-
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -3397,12 +3326,6 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/coverage-v8@1.6.1':
     resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
@@ -4710,11 +4633,11 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -6640,9 +6563,6 @@ packages:
     engines: {node: '>=20.16.0 <21 || >=22.3.0'}
     hasBin: true
 
-  pdf-poppler@0.2.3:
-    resolution: {integrity: sha512-nUczP3M/W4c8/3F6il0LmkxkF33qTKQyxeBmUnPbQLxxhtBX42zfpZqnLysomvMdb756qVR7n5kvNr+LzisXQw==}
-
   pdf-to-png-converter@3.14.0:
     resolution: {integrity: sha512-WvCrXZrZBK/z9j+iLLA40e8kCrT2qme84WXUSmlfbiKZs5d4iZ8AVZF34LpMGvvPHN3oyv0hRcEIr6C9tiTQXA==}
     engines: {node: '>=20'}
@@ -7088,10 +7008,6 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -7245,10 +7161,6 @@ packages:
     peerDependencies:
       react-loadable: '*'
       webpack: '>=4.41.1 || 5.x'
-
-  react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
 
   react-router-config@5.1.1:
     resolution: {integrity: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==}
@@ -7481,10 +7393,6 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  sax@1.4.4:
-    resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
-    engines: {node: '>=11.0.0'}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -7917,10 +7825,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -8178,6 +8082,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   value-equal@1.0.1:
@@ -8662,7 +8567,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -8688,29 +8593,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.5': {}
-
   '@babel/compat-data@7.29.0': {}
-
-  '@babel/core@7.28.5':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/core@7.29.0':
     dependencies:
@@ -8732,14 +8615,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.28.5':
-    dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
   '@babel/generator@7.29.1':
     dependencies:
       '@babel/parser': 7.29.2
@@ -8751,14 +8626,6 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/helper-compilation-targets@7.27.2':
-    dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
-      lru-cache: 5.1.1
-      semver: 6.3.1
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -8808,26 +8675,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -8884,11 +8735,6 @@ snapshots:
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helpers@7.28.4':
-    dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
 
   '@babel/helpers@7.29.2':
     dependencies:
@@ -9256,16 +9102,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -9485,29 +9321,11 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@babel/template@7.27.2':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
-
-  '@babel/traverse@7.28.5':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -10510,7 +10328,7 @@ snapshots:
       infima: 0.2.0-alpha.45
       lodash: 4.17.23
       nprogress: 0.2.0
-      postcss: 8.5.6
+      postcss: 8.5.8
       prism-react-renderer: 2.4.1(react@18.3.1)
       prismjs: 1.30.0
       react: 18.3.1
@@ -11654,8 +11472,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
-
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
@@ -11769,81 +11585,37 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
 
   '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-
   '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
 
   '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-
   '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
 
   '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-
   '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-
   '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-
-  '@svgr/babel-preset@8.1.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.28.5)
 
   '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
     dependencies:
@@ -11859,8 +11631,8 @@ snapshots:
 
   '@svgr/core@8.1.0(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
@@ -12044,27 +11816,6 @@ snapshots:
     optional: true
 
   '@types/aria-query@5.0.4': {}
-
-  '@types/babel__core@7.20.5':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -12316,7 +12067,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 25.5.0
 
   '@types/send@0.17.6':
     dependencies:
@@ -12450,18 +12201,6 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
-
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.0))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@25.5.0)(jsdom@29.0.1(canvas@3.2.2))(lightningcss@1.32.0)(terser@5.46.0))':
     dependencies:
@@ -14072,7 +13811,7 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-react-hooks@7.0.1(eslint@10.1.0(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.1.0(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -14814,7 +14553,7 @@ snapshots:
       html-minifier-terser: 6.1.0
       lodash: 4.17.23
       pretty-error: 4.0.0
-      tapable: 2.3.0
+      tapable: 2.3.2
     optionalDependencies:
       webpack: 5.105.3
 
@@ -16100,7 +15839,7 @@ snapshots:
   mini-css-extract-plugin@2.10.0(webpack@5.105.3):
     dependencies:
       schema-utils: 4.3.3
-      tapable: 2.3.0
+      tapable: 2.3.2
       webpack: 5.105.3
 
   miniflare@4.20260317.2:
@@ -16490,8 +16229,6 @@ snapshots:
     dependencies:
       '@napi-rs/canvas': 0.1.80
       pdfjs-dist: 5.4.296
-
-  pdf-poppler@0.2.3: {}
 
   pdf-to-png-converter@3.14.0:
     dependencies:
@@ -16989,12 +16726,6 @@ snapshots:
     dependencies:
       postcss: 8.5.8
 
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -17147,8 +16878,6 @@ snapshots:
       '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
       webpack: 5.105.3
-
-  react-refresh@0.17.0: {}
 
   react-router-config@5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -17527,8 +17256,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.4.4: {}
-
   sax@1.6.0: {}
 
   saxes@6.0.0:
@@ -17759,7 +17486,7 @@ snapshots:
       '@types/node': 17.0.45
       '@types/sax': 1.2.7
       arg: 5.0.2
-      sax: 1.4.4
+      sax: 1.6.0
 
   skin-tone@2.0.0:
     dependencies:
@@ -18055,8 +17782,6 @@ snapshots:
   tiny-warning@1.0.3: {}
 
   tinybench@2.9.0: {}
-
-  tinyexec@1.0.2: {}
 
   tinyexec@1.0.4: {}
 
@@ -18715,7 +18440,7 @@ snapshots:
 
   xml-js@1.6.11:
     dependencies:
-      sax: 1.4.4
+      sax: 1.6.0
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,9 @@ packages:
   - scripts/md-formatter
 
 onlyBuiltDependencies:
+  # canvas is only jsdom's (vitest) optional rendering capability — no first-party code imports it.
+  # Kept (not dropped) because removing it forces a full lockfile regen; left in the allowlist so its
+  # native build runs. If a stale local install loses build/Release/canvas.node, run `pnpm rebuild`.
   - canvas
   - sharp
   - esbuild
@@ -25,6 +28,12 @@ trustPolicyExclude:
 strictPeerDependencies: false
 # Auto-install non-optional peers (compatibility)
 autoInstallPeers: true
+# Silence the eslint 10 unmet-peer warning for eslint-plugin-react: no released version
+# declares an eslint ^10 peer yet (latest 7.37.5 caps at ^9.7; lint passes on eslint 10 today).
+# Remove this entry once jsx-eslint/eslint-plugin-react ships eslint-10 peer support.
+peerDependencyRules:
+  allowedVersions:
+    'eslint-plugin-react>eslint': '10'
 # Fully flat node_modules — needed for Docusaurus (and legacy Next.js) module resolution
 shamefullyHoist: true
 # Hoist these to the root node_modules so they resolve from outside their declaring package.

--- a/scripts/md-formatter/src/cli.js
+++ b/scripts/md-formatter/src/cli.js
@@ -16,7 +16,7 @@ program
   .option(
     '--ignore <patterns>',
     'Comma-separated patterns to ignore',
-    '**/node_modules/**,dist/**,dev/**,build/**,.git/**,worktrees/**,sub-packages/**,__inbox/**',
+    '**/node_modules/**,dist/**,dev/**,build/**,.git/**,worktrees/**,sub-packages/**,__inbox/**,test-results/**,playwright-report/**',
   )
   .action(async (patterns, options) => {
     try {

--- a/scripts/test-all-pages-fast.js
+++ b/scripts/test-all-pages-fast.js
@@ -11,31 +11,54 @@
  * Asset paths changed from /manuals/_next/static/* to /manuals/assets/* but
  * this script tests page HTTP status, not asset presence.
  *
+ * Manuals are discovered dynamically by scanning `public/<slug>/data/manifest.json`
+ * (the same approach as `discoverManualSlugs()` in scripts/pdf-search-index-all.js),
+ * so EVERY manual registered under public/ is smoke-tested — there is no
+ * hardcoded list to drift out of sync with lib/zfb-registry.generated.ts.
+ *
  * Environment variables:
  *   BASE_URL - Server base URL (default: http://localhost:8030)
  */
 
-import { createRequire } from 'module';
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
+const PUBLIC_DIR = join(__dirname, '..', 'public');
 
-// Read all manifests directly from the data directories
-const oxiOneMk2Manifest = require('../public/oxi-one-mk2/data/manifest.json');
-const oxiCoralManifest = require('../public/oxi-coral/data/manifest.json');
-const oxiE16QuickStartManifest = require('../public/oxi-e16-quick-start/data/manifest.json');
-const oxiE16ManualManifest = require('../public/oxi-e16-manual/data/manifest.json');
-const addac112LooperManifest = require('../public/addac112-looper/data/manifest.json');
+/**
+ * Discover every manual under `publicDir` that has a `data/manifest.json`,
+ * returning a map of slug -> parsed manifest. Mirrors the discovery pattern in
+ * scripts/pdf-search-index-all.js but keys on manifest.json (this crawler needs
+ * `totalPages`, not the search-index's pages-ja.json). Non-directory entries
+ * (`_headers`, `_redirects`) and dirs without a manifest (`img/`) are skipped.
+ *
+ * @param {string} publicDir
+ * @returns {Record<string, { totalPages: number }>} slug -> manifest
+ */
+function discoverManuals(publicDir) {
+  const manuals = {};
+  if (!existsSync(publicDir)) return manuals;
 
-const MANUALS = {
-  'addac112-looper': addac112LooperManifest,
-  'oxi-coral': oxiCoralManifest,
-  'oxi-e16-manual': oxiE16ManualManifest,
-  'oxi-e16-quick-start': oxiE16QuickStartManifest,
-  'oxi-one-mk2': oxiOneMk2Manifest,
-};
+  for (const name of readdirSync(publicDir)) {
+    const abs = join(publicDir, name);
+    let st;
+    try {
+      st = statSync(abs);
+    } catch {
+      continue;
+    }
+    if (!st.isDirectory()) continue;
+    const manifestPath = join(abs, 'data', 'manifest.json');
+    if (!existsSync(manifestPath)) continue;
+    manuals[name] = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  }
+
+  return manuals;
+}
+
+const MANUALS = discoverManuals(PUBLIC_DIR);
 
 // Default changed from zmanuals.localhost:3100 (Next.js dev) to localhost:8030
 // (zfb production-serve / pnpm serve). Override with BASE_URL env var if needed.
@@ -91,6 +114,13 @@ async function main() {
 
   // Get all manuals
   const manualIds = Object.keys(MANUALS).sort();
+
+  // Fail loudly on an empty discovery — otherwise a misconfigured public/ dir
+  // would silently "pass" with zero pages tested.
+  if (manualIds.length === 0) {
+    console.error('❌ No manuals discovered under public/*/data/manifest.json — nothing to test.');
+    process.exit(1);
+  }
 
   // Calculate total pages
   for (const manualId of manualIds) {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/takazudomodular-manuals/issues/202
- parent PR
    - https://github.com/Takazudo/takazudomodular-manuals/pull/193

---

## Summary

- Batch-fixes all 6 open `agent-found` issues from the zfb next.38 bump verification: #196, #197, #198, #199, #200, #201 (tracking: #202)
- Playwright now actually runs in CI: new **E2E Interaction Tests** job on every PR (50 interaction tests, builds in-job, cached chromium) + non-gating full suite on main push (`main-e2e.yml`) — absorbs PR #195's e2e assertion fixes as the stated prerequisite
- Smoke crawler discovers all **52 manuals (1152 pages)** dynamically instead of a hardcoded 5; the misleading "E2E Smoke Tests" job is renamed **Page Smoke Crawler** with honest PR-comment text
- Dependency hygiene: eslint 10 peer warnings eliminated, dead `pnpm.onlyBuiltDependencies` removed, unused devDeps dropped, all `@docusaurus/*` pinned exactly `3.9.2`; md-formatter no longer scans Playwright artifacts

## Changes

### e2e / CI (#196 needs-decision — conservative choices, #197)
- `.github/workflows/pr-quality-checks.yml`: new `e2e-interaction` job (PR-level, no branches filter — this very PR exercises it); crawler job renamed + `if:` gate kept in sync with the artifact-upload gate
- `.github/workflows/main-e2e.yml`: full Playwright suite on push to main, **non-gating** (deploy does not depend on it; reversible by deleting one file)
- `playwright.config.ts`: `SKIP_ZFB_BUILD=1` escape hatch actually implemented (serve existing `dist/` without rebuilding; default behavior unchanged)
- `scripts/test-all-pages-fast.js`: dynamic `public/*/data/manifest.json` discovery; empty discovery now exits non-zero
- `e2e/`: merged PR #195 (island-readiness waits + 3 broken nav/scroll assertions); `viewer-ui.spec.ts` got the same hydration wait in all 11 interaction tests (deep-review finding, flake prevention)

### Dependency hygiene (#198, #200, #201)
- `package.json`: `eslint-plugin-react-hooks` ^7.1.1 (eslint 10 peer support); removed dead `pnpm.onlyBuiltDependencies`, unused `pdf-poppler` + `@vitejs/plugin-react`
- `pnpm-workspace.yaml`: `peerDependencyRules.allowedVersions` for `eslint-plugin-react` (remove once upstream ships eslint-10 support); **canvas kept** deliberately — jsdom pins it as optional peer, full purge would drift ~20 unrelated deps; `pnpm rebuild` documented for stale installs
- `doc/package.json`: all `@docusaurus/*` exact-pinned `3.9.2` (prevents mixed-version install that Docusaurus hard-fails on)

### md-formatter (#199)
- `scripts/md-formatter/src/cli.js`: default ignore list extended with `test-results/**` + `playwright-report/**` (cli-side default — `--ignore` would replace the list)

## Test Plan

- [x] `pnpm check` + `pnpm test:unit` (175/175) on merged result
- [x] `pnpm build` (zfb + doc) green
- [x] CI interaction subset locally with exact CI args: 50/50 passed; viewer-ui re-run after hydration fix: 13/13
- [x] md-formatter dual-path verification with deliberately-bad dummy artifacts (old list flags them, new list excludes them, normal markdown still checked)
- [x] `pnpm install --frozen-lockfile` passes; eslint peer warnings gone
- [x] CI on this PR: all 6 checks green — including the new E2E Interaction Tests job proving itself