### PR TITLE
fix(pdf:render): stop leaking stray ./home/* intermediate PNGs

### DIFF
--- a/scripts/pdf-render-pages.js
+++ b/scripts/pdf-render-pages.js
@@ -88,8 +88,11 @@ async function renderPdfPages() {
       // Convert PDF to PNG
       const scale = dpi / 72;
 
+      // No outputFolder: pdf-to-png-converter only writes PNGs to disk when it is set,
+      // and it leaks stray copies under a relative ./home/<abs-path-mirror>/ tree. We
+      // already persist pngPages[0].content ourselves below, so omit it (content is
+      // still returned because returnPageContent defaults to true).
       const pngPages = await pdfToPng(pagePath, {
-        outputFolder: outputDir,
         viewportScale: scale,
         pngOptions: {
           quality: 100,


### PR DESCRIPTION
Fixes #206 (raised by the `/x-as-pr` run that added the ADDAC120S manual).

## Problem

`pnpm run pdf:render` left a stray `home/<abs-path-mirror>/.../pages/page-*_page_1.png` tree at the repo root — untracked, not gitignored, one junk PNG per page, on every render for every slug.

## Cause

`pdf-to-png-converter`'s `pdfToPng(...)` writes PNGs to disk **only** when `outputFolder` is set (its on-disk name is `*_page_1.png`). The script passed `outputFolder: outputDir` **and** separately `writeFileSync`s the correct `page-NN.png` from the in-memory `pngPages[0].content` — so the library's disk write was a redundant duplicate that leaked to a relative `./home/...` path.

## Fix

Drop the `outputFolder` option. `content` is still returned (`returnPageContent` defaults to `true`), so the script's own `writeFileSync` is unaffected — and the library no longer writes anything to disk.

## Verification

Re-rendered an existing manual (`addac104-tnetw`) with the change: all pages render correctly and **no `./home/` directory is created**.

---
*Auto-fix of an `agent-found` issue during the `/x-as-pr` workflow.*