### PR TITLE
fix(viewer): reset scroll position on page navigation

### DIFF
--- a/components/__tests__/page-viewer.test.tsx
+++ b/components/__tests__/page-viewer.test.tsx
@@ -107,3 +107,91 @@ describe('PageViewer — language wiring', () => {
     expect(msg.textContent).toBe('No text extracted for this page.');
   });
 });
+
+describe('PageViewer — scroll reset on navigation', () => {
+  // jsdom implements no layout, so an element's scrollTop is effectively a
+  // no-op (always 0). Back it with a real settable property so a "scrolled
+  // down" precondition can be simulated and the reset asserted.
+  const makeScrollable = (el: Element) => {
+    let value = 0;
+    Object.defineProperty(el, 'scrollTop', {
+      configurable: true,
+      get: () => value,
+      set: (n: number) => {
+        value = n;
+      },
+    });
+  };
+
+  it('resets both scroll columns to the top when the page changes', () => {
+    const { rerender } = render(
+      <PageViewer
+        page={pageWithContent('ja')}
+        lang="ja"
+        currentPage={1}
+        totalPages={10}
+        manualId="oxi-one-mk2"
+        onNavigate={vi.fn()}
+        onNavigateHome={vi.fn()}
+      />,
+    );
+
+    const imageScroll = screen.getByTestId('page-image-scroll');
+    const translationCol = screen.getByTestId('translation-column');
+    makeScrollable(imageScroll);
+    makeScrollable(translationCol);
+
+    // Simulate the user scrolling down on the current page.
+    imageScroll.scrollTop = 500;
+    translationCol.scrollTop = 800;
+
+    // Navigate to a different page (every nav path flows through currentPage).
+    rerender(
+      <PageViewer
+        page={{ ...pageWithContent('ja'), pageNum: 2 }}
+        lang="ja"
+        currentPage={2}
+        totalPages={10}
+        manualId="oxi-one-mk2"
+        onNavigate={vi.fn()}
+        onNavigateHome={vi.fn()}
+      />,
+    );
+
+    expect(imageScroll.scrollTop).toBe(0);
+    expect(translationCol.scrollTop).toBe(0);
+  });
+
+  it('does not reset scroll on re-render that keeps the same page (e.g. language toggle)', () => {
+    const { rerender } = render(
+      <PageViewer
+        page={pageWithContent('ja')}
+        lang="ja"
+        currentPage={3}
+        totalPages={10}
+        manualId="oxi-one-mk2"
+        onNavigate={vi.fn()}
+        onNavigateHome={vi.fn()}
+      />,
+    );
+
+    const translationCol = screen.getByTestId('translation-column');
+    makeScrollable(translationCol);
+    translationCol.scrollTop = 600;
+
+    // Same currentPage — only the language changes. Scroll should be preserved.
+    rerender(
+      <PageViewer
+        page={pageWithContent('en')}
+        lang="en"
+        currentPage={3}
+        totalPages={10}
+        manualId="oxi-one-mk2"
+        onNavigate={vi.fn()}
+        onNavigateHome={vi.fn()}
+      />,
+    );
+
+    expect(translationCol.scrollTop).toBe(600);
+  });
+});

--- a/components/zfb/page-viewer.tsx
+++ b/components/zfb/page-viewer.tsx
@@ -58,6 +58,10 @@ export function PageViewer({
   const [hasError, setHasError] = useState(false);
   const prevPageRef = useRef({ currentPage, manualId });
   const imgRef = useRef<HTMLImageElement>(null);
+  // The left image column and right translation column each scroll
+  // independently (both are overflow-y-scroll). Refs let us reset them to the
+  // top whenever the page changes — see the scroll-reset effect below.
+  const imageScrollRef = useRef<HTMLDivElement>(null);
 
   // ── Hover-zoom (Amazon-style magnifier) ──────────────────────────────────
   // Lens overlays the source image; the panel fills the translation column and
@@ -193,6 +197,18 @@ export function PageViewer({
     prevPageRef.current = { currentPage, manualId };
   }, [currentPage, manualId]);
 
+  // Reset both scroll columns to the top on every page change. All in-manual
+  // navigation (次へ/前へ, the page selector, thumbnails, keyboard, browser
+  // back/forward) flows through `currentPage`, so this one effect covers every
+  // path. Without it the columns keep the previous page's scroll offset and the
+  // new page appears mid-scrolled (#180-adjacent). useLayoutEffect runs after
+  // the DOM updates but before paint, so there is no flash of the old position.
+  // Mirrors ScrollViewer's translation-column reset; page mode only.
+  useLayoutEffect(() => {
+    if (contentColRef.current) contentColRef.current.scrollTop = 0;
+    if (imageScrollRef.current) imageScrollRef.current.scrollTop = 0;
+  }, [currentPage, manualId]);
+
   // Disabling zoom mid-hover must hide the UI immediately.
   useEffect(() => {
     if (!zoomEnabled) deactivateZoom();
@@ -226,7 +242,11 @@ export function PageViewer({
       <div className={viewerContainerStyles}>
         {/* Left Column: PDF Image */}
         <div className={viewerImageColumnOuterStyles} data-testid="page-image-column">
-          <div className={viewerImageColumnStyles} data-testid="page-image-scroll">
+          <div
+            ref={imageScrollRef}
+            className={viewerImageColumnStyles}
+            data-testid="page-image-scroll"
+          >
             <div className={viewerImageWrapperStyles} data-testid="page-image-wrapper">
               {hasError ? (
                 <div className={loaderWrapperStyles} data-testid="page-image-error">

--- a/e2e/viewer-ui.spec.ts
+++ b/e2e/viewer-ui.spec.ts
@@ -262,6 +262,42 @@ test.describe('Viewer UI: Page-mode loading overlay (#180)', () => {
   });
 });
 
+test.describe('Viewer UI: Page-mode scroll reset on navigation', () => {
+  test('resets both column scroll positions to the top when navigating pages', async ({ page }) => {
+    await page.goto(PAGE_URL); // /manuals/oxi-one-mk2/page/5
+    await waitForViewerNavReady(page);
+
+    const imageScroll = page.getByTestId('page-image-scroll');
+    const translationCol = page.getByTestId('translation-column');
+    await expect(imageScroll).toBeVisible();
+    await expect(translationCol).toBeVisible();
+
+    // Scroll both columns down (each is an independent overflow-y-scroll pane).
+    await imageScroll.evaluate((el) => {
+      el.scrollTop = 500;
+    });
+    await translationCol.evaluate((el) => {
+      el.scrollTop = 500;
+    });
+
+    // Precondition: at least one column actually moved off the top (values clamp
+    // to each pane's max scroll, so they may be < 500).
+    const before = await Promise.all([
+      imageScroll.evaluate((el) => el.scrollTop),
+      translationCol.evaluate((el) => el.scrollTop),
+    ]);
+    expect(Math.max(...before)).toBeGreaterThan(0);
+
+    // Navigate to the next page via the 次へ button.
+    await page.getByTestId('next-page-button').click();
+    await expect(page.getByTestId('page-selector')).toHaveValue('6');
+
+    // Both panes must be back at the top of the new page (#scroll-reset).
+    await expect.poll(() => imageScroll.evaluate((el) => el.scrollTop)).toBe(0);
+    await expect.poll(() => translationCol.evaluate((el) => el.scrollTop)).toBe(0);
+  });
+});
+
 test.describe('Viewer UI: No Console Errors', () => {
   test('should not have console errors during UI interactions', async ({ page }) => {
     const consoleErrors: string[] = [];


### PR DESCRIPTION
## Problem

In page mode, navigating to another page kept the previous page's scroll position — the new page appeared mid-scrolled (reported on `/manuals/addac120s-strings/page/24`: scroll down page 2, click 次へ, page 3 opens already scrolled).

Both viewer columns are independent `overflow-y-scroll` panes, and re-rendering new content does not reset their `scrollTop`. `ScrollViewer` already guards its column; `PageViewer` had no equivalent.

## Fix

`PageViewer` now resets both the image column and the translation column to the top via a `useLayoutEffect` keyed on `currentPage`/`manualId`. Every in-manual nav path (次へ/前へ, page selector, thumbnails, keyboard, browser back/forward) flows through `currentPage`, so one effect covers them all. It runs before paint (no flash) and is scoped to page mode. A same-page re-render (e.g. language toggle) keeps `currentPage`, so scroll is intentionally preserved.

## Tests

- **Unit** (`page-viewer.test.tsx`): resets both columns on page change; preserves scroll on same-page re-render (language toggle). Uses a settable `scrollTop` shim since jsdom has no layout.
- **E2E** (`viewer-ui.spec.ts`): scrolls both columns on page 5, clicks 次へ, asserts both return to `0` on page 6.
- Verified in a real browser (dev server): before 122/195 → after 0/0.