### PR TITLE
docs(runbook): fix zzmod redirect issue reference (zudolab/zzmod#724)

### DIFF
--- a/doc/docs/inbox/cf-workers-cutover.md
+++ b/doc/docs/inbox/cf-workers-cutover.md
@@ -132,7 +132,7 @@ the redirect rule to `_redirects-pages`:
 /manuals/* https://manuals.takazudomodular.com/:splat 301
 ```
 
-**zzmod issue:** [Takazudo/zmodular#1831](https://github.com/Takazudo/zmodular/issues/1831)
+**zzmod issue:** [zudolab/zzmod#724](https://github.com/zudolab/zzmod/issues/724)
 
 > Apply this redirect **after** Step 3 (live site verified). Applying it before
 > the Worker is live on `manuals.takazudomodular.com` would cause errors for


### PR DESCRIPTION
Corrects the cross-repo redirect tracking-issue reference in the CF Workers cutover runbook.

The S9 sub-task (#220) filed the issue in the wrong repo (`Takazudo/zmodular#1831`). The local `zzmod` dir actually maps to **`zudolab/zzmod`** (which holds `_redirects-pages`). Re-filed at **zudolab/zzmod#724**; the misfiled `zmodular#1831` was closed with a pointer.

One-line doc reference fix. Follow-up to epic #211 / PR #221.