### PR TITLE
chore(doc): regenerate stale doc-data (category-nav, doc-titles)

### DIFF
--- a/doc/src/data/category-nav.json
+++ b/doc/src/data/category-nav.json
@@ -8,7 +8,7 @@
       },
       {
         "docId": "inbox/pr-preview-url",
-        "title": "PR Preview URL (Cloudflare Pages)",
+        "title": "PR Preview URL (Cloudflare Workers)",
         "position": 60
       },
       {
@@ -20,6 +20,11 @@
         "docId": "inbox/migration-nextjs-to-zfb",
         "title": "Migration — Next.js → zfb",
         "position": 70
+      },
+      {
+        "docId": "inbox/cf-workers-cutover",
+        "title": "Cloudflare Workers Cutover Runbook",
+        "position": 80
       },
       {
         "docId": "inbox/design-system",

--- a/doc/src/data/doc-titles.json
+++ b/doc/src/data/doc-titles.json
@@ -1,9 +1,10 @@
 {
   "inbox/bilingual-support": "Bilingual Support (JA / EN)",
+  "inbox/cf-workers-cutover": "Cloudflare Workers Cutover Runbook",
   "inbox/csp-hardening-plan": "CSP Flip-to-Enforced Hardening Plan",
   "inbox/design-system": "Design System",
   "inbox/index": "INBOX",
   "inbox/migration-nextjs-to-zfb": "Migration — Next.js → zfb",
   "inbox/pdf-to-nextjs-architecture": "PDF Processing Architecture",
-  "inbox/pr-preview-url": "PR Preview URL (Cloudflare Pages)"
+  "inbox/pr-preview-url": "PR Preview URL (Cloudflare Workers)"
 }


### PR DESCRIPTION
Closes #226

## Summary

Regenerate `doc/src/data/category-nav.json` and `doc/src/data/doc-titles.json` via the doc generator scripts (`generate-category-nav.js`, `generate-doc-titles.js`). The committed copies had drifted behind doc content merged in earlier PRs:

- "PR Preview URL (Cloudflare **Pages**)" → "Cloudflare **Workers**"
- added the missing `inbox/cf-workers-cutover` ("Cloudflare Workers Cutover Runbook") entry

Surfaced by `pnpm build` while bumping zfb to next.53 (PR #225); split out to keep that PR atomic. Pure regenerated generated-data — no source/logic change.

## Test Plan

- Output matches `pnpm build`'s regeneration exactly.
- CI Build Check (runs `doc:build`) verifies the doc site builds with the regenerated data.