### PR TITLE
fix: stuck page-image loader overlay + allow Cloudflare Web Analytics beacon in CSP

### DIFF
--- a/components/__tests__/page-viewer.test.tsx
+++ b/components/__tests__/page-viewer.test.tsx
@@ -9,7 +9,7 @@
  * onNavigateHome as callbacks; navigation is owned by the island.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/preact';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/preact';
 import type { ManualPage } from '@/lib/types/manual';
 import { PageViewer } from '../zfb/page-viewer';
 
@@ -193,5 +193,83 @@ describe('PageViewer — scroll reset on navigation', () => {
     );
 
     expect(translationCol.scrollTop).toBe(600);
+  });
+});
+
+describe('PageViewer — loading overlay', () => {
+  const renderPage = () =>
+    render(
+      <PageViewer
+        page={pageWithContent('ja')}
+        lang="ja"
+        currentPage={1}
+        totalPages={10}
+        manualId="oxi-one-mk2"
+        onNavigate={vi.fn()}
+        onNavigateHome={vi.fn()}
+      />,
+    );
+
+  it('clears the loading overlay once the image fires its load event', () => {
+    renderPage();
+    const overlay = screen.getByTestId('page-image-overlay');
+    expect(overlay.className).toContain('opacity-100');
+
+    fireEvent.load(screen.getByTestId('page-image'));
+
+    expect(overlay.className).toContain('opacity-0');
+    expect(overlay.className).not.toContain('opacity-100');
+  });
+
+  // Regression: after ManualApp swaps the SSR body for the real PageViewer, the
+  // fresh <img> points at an already-cached PNG. Its `load` event can fire in
+  // the gap before Preact's onLoad listener is effective, and `complete` may not
+  // yet be true at the synchronous mount-time check — leaving the overlay stuck
+  // at opacity-100 over a fully loaded image. The post-mount rAF re-check must
+  // clear it even though onLoad never fires. (Without the re-check this hangs.)
+  it('clears the loading overlay for a cached image even when onLoad never fires', () => {
+    const proto = window.HTMLImageElement.prototype;
+    const origComplete = Object.getOwnPropertyDescriptor(proto, 'complete');
+    const origNaturalWidth = Object.getOwnPropertyDescriptor(proto, 'naturalWidth');
+    let imgComplete = false;
+    Object.defineProperty(proto, 'complete', { configurable: true, get: () => imgComplete });
+    Object.defineProperty(proto, 'naturalWidth', {
+      configurable: true,
+      get: () => (imgComplete ? 800 : 0),
+    });
+
+    // Capture the scheduled rAF callback so we can fire it deterministically
+    // after flipping the image to "cached/complete" — no onLoad event is ever
+    // dispatched, mirroring the missed-listener race.
+    let rafCb: FrameRequestCallback | null = null;
+    const rafSpy = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        rafCb = cb;
+        return 1;
+      });
+    const cafSpy = vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    try {
+      renderPage();
+      const overlay = screen.getByTestId('page-image-overlay');
+      // Image not yet complete at mount → overlay still showing, rAF scheduled.
+      expect(overlay.className).toContain('opacity-100');
+      expect(rafCb).not.toBeNull();
+
+      // The cached image becomes complete with no load event firing.
+      imgComplete = true;
+      act(() => {
+        rafCb?.(0);
+      });
+
+      expect(overlay.className).toContain('opacity-0');
+      expect(overlay.className).not.toContain('opacity-100');
+    } finally {
+      rafSpy.mockRestore();
+      cafSpy.mockRestore();
+      if (origComplete) Object.defineProperty(proto, 'complete', origComplete);
+      if (origNaturalWidth) Object.defineProperty(proto, 'naturalWidth', origNaturalWidth);
+    }
   });
 });

--- a/components/zfb/page-viewer.tsx
+++ b/components/zfb/page-viewer.tsx
@@ -199,8 +199,14 @@ export function PageViewer({
       return false;
     };
     if (clearIfComplete()) return;
-    const raf = requestAnimationFrame(clearIfComplete);
-    return () => cancelAnimationFrame(raf);
+    // Re-check after the current frame. Prefer rAF; fall back to a macrotask in
+    // any environment where rAF is unavailable, so the effect never throws.
+    if (typeof requestAnimationFrame === 'function') {
+      const raf = requestAnimationFrame(clearIfComplete);
+      return () => cancelAnimationFrame(raf);
+    }
+    const timer = setTimeout(clearIfComplete, 0);
+    return () => clearTimeout(timer);
   }, [currentPage, manualId, page.image]);
 
   // Reset loading state when navigating to a different page

--- a/components/zfb/page-viewer.tsx
+++ b/components/zfb/page-viewer.tsx
@@ -179,13 +179,29 @@ export function PageViewer({
     deactivateZoom();
   }, [deactivateZoom]);
 
-  // Check if image is already loaded on mount (handles cached images).
-  // useLayoutEffect runs before paint, preventing flicker.
+  // Clear the loading overlay for an already-loaded (cached) image. This is the
+  // common path after ManualApp swaps the SSR body for the real PageViewer: the
+  // fresh <img> points at a PNG the browser already cached, so its `load` event
+  // can fire in the gap before Preact's onLoad listener is effective, and
+  // `complete` may not yet be true at this synchronous mount-time snapshot.
+  // Relying on either alone left the overlay stuck at opacity-100 over a fully
+  // loaded image (intermittent "spinner never goes away; reload fixes it").
+  // We check now AND re-check on the next frame as a safety net; onLoad still
+  // covers the genuinely-uncached case. page.image is in the deps so a src
+  // change (client-side navigation) re-evaluates.
   useLayoutEffect(() => {
-    if (imgRef.current?.complete && (imgRef.current?.naturalWidth ?? 0) > 0) {
-      setIsLoading(false);
-    }
-  }, [currentPage, manualId]);
+    const clearIfComplete = () => {
+      const img = imgRef.current;
+      if (img?.complete && img.naturalWidth > 0) {
+        setIsLoading(false);
+        return true;
+      }
+      return false;
+    };
+    if (clearIfComplete()) return;
+    const raf = requestAnimationFrame(clearIfComplete);
+    return () => cancelAnimationFrame(raf);
+  }, [currentPage, manualId, page.image]);
 
   // Reset loading state when navigating to a different page
   useEffect(() => {

--- a/doc/src/content/docs/infrastructure/csp.md
+++ b/doc/src/content/docs/infrastructure/csp.md
@@ -13,10 +13,12 @@ The zmanuals site (`manuals.takazudomodular.com`) enforces a Content Security Po
 ## Enforced directive (viewer surface `/*`)
 
 ```
-Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-hIolMSvWhopr46DqQi50arv0b3/qeN3LLlH0NTMq3K8='; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
+Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com 'sha256-hIolMSvWhopr46DqQi50arv0b3/qeN3LLlH0NTMq3K8='; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
 ```
 
 - `script-src`: uses the SHA-256 hash of `LANG_BOOTSTRAP_SCRIPT` (the only inline script, defined as a build-time constant in `layouts/default.tsx`). When a hash is present browsers ignore `'unsafe-inline'`, so no unsafe token is needed.
+
+- `script-src` also allows `https://static.cloudflareinsights.com`: Cloudflare auto-injects the [Web Analytics](https://developers.cloudflare.com/web-analytics/) beacon (`beacon.min.js`) at the edge — it is not in our source, so a hash cannot cover it and the host must be allow-listed instead. Without this the beacon is blocked and every page logs a `script-src` CSP violation. The beacon reports RUM to the same origin (`/cdn-cgi/rum`), which `connect-src 'self'` already covers, so no `connect-src` change is needed.
 
   The hash was computed from the literal script string:
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,8 +1,5 @@
-# script-src must allow https://static.cloudflareinsights.com: Cloudflare
-# auto-injects the Web Analytics beacon (beacon.min.js) at the edge, so it is
-# not in our source. The beacon reports RUM to the same origin (/cdn-cgi/rum),
-# which connect-src 'self' already covers, so only the script host is needed.
-# See https://developers.cloudflare.com/web-analytics/
+# script-src allows static.cloudflareinsights.com for the edge-injected
+# Cloudflare Web Analytics beacon — rationale in doc/.../infrastructure/csp.md
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff

--- a/public/_headers
+++ b/public/_headers
@@ -1,8 +1,13 @@
+# script-src must allow https://static.cloudflareinsights.com: Cloudflare
+# auto-injects the Web Analytics beacon (beacon.min.js) at the edge, so it is
+# not in our source. The beacon reports RUM to the same origin (/cdn-cgi/rum),
+# which connect-src 'self' already covers, so only the script host is needed.
+# See https://developers.cloudflare.com/web-analytics/
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-hIolMSvWhopr46DqQi50arv0b3/qeN3LLlH0NTMq3K8='; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com 'sha256-hIolMSvWhopr46DqQi50arv0b3/qeN3LLlH0NTMq3K8='; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'
 
 /doc
   ! Content-Security-Policy


### PR DESCRIPTION
## Summary

Fixes two issues reproduced on the deployed viewer (e.g. `/addac120s-strings/page/3`):

1. **Stuck page-image loading overlay** — intermittently the left PDF-page column shows a spinner that never clears (reloading fixes it). After `ManualApp` swaps the SSR body for the real `<PageViewer>`, a fresh `<img>` points at an already-cached PNG; its `load` event can fire before Preact's `onLoad` listener is effective, and `complete` may not yet be true at the single mount-time snapshot — so `isLoading` never flips and the overlay stays at `opacity-100` over a fully loaded image.
2. **CSP console error** — the Cloudflare Web Analytics beacon (edge-injected `https://static.cloudflareinsights.com/beacon.min.js`) is blocked by `Content-Security-Policy: … script-src 'self' …`, logging *"The action has been blocked"* on every page.

## Changes

- **`components/zfb/page-viewer.tsx`** — replace the single mount-time `complete` snapshot with a sync check **plus** a next-frame re-check (rAF, with a `setTimeout` fallback where rAF is unavailable). Keyed on `page.image` so client-side navigation re-evaluates. `onLoad`/`onError` still cover the genuinely-uncached path. This guarantees the loader overlay clears for an already-cached image even if `onLoad` is missed.
- **`public/_headers`** — add `https://static.cloudflareinsights.com` to `script-src`. The beacon reports RUM to the same origin (`/cdn-cgi/rum`), already covered by `connect-src 'self'`, so no `connect-src` change is needed.
- **`doc/src/content/docs/infrastructure/csp.md`** — document the beacon allowance (the project's home for CSP rationale); the `_headers` inline note is a one-line pointer.
- **`components/__tests__/page-viewer.test.tsx`** — regression tests: overlay clears on `load`, and clears for a cached image via the rAF re-check even when `onLoad` never fires.

## Test Plan

- `pnpm check` (typecheck + lint + format) ✅
- `pnpm test:unit` — 183 tests pass (incl. new loader-overlay regression tests) ✅
- `pnpm build` — production build succeeds; `dist/_headers` carries the updated CSP ✅
- Reviewed via `/codex-review`; the one finding (guard `requestAnimationFrame`) is addressed with a `setTimeout` fallback.

## Notes

- The Web Analytics beacon is injected automatically at the Cloudflare edge (Web Analytics enabled on the zone), not present in our source — so it can't be hash-covered and the host must be allow-listed. Disabling it would be a dashboard change, out of repo scope; the site keeps analytics and the CSP error is resolved.